### PR TITLE
feat(go-core): add runners e2e tests

### DIFF
--- a/suites/go-core/buf.gen.yaml
+++ b/suites/go-core/buf.gen.yaml
@@ -10,6 +10,7 @@ inputs:
   - module: buf.build/agynio/api
     paths:
       - agynio/api/agents/v1
+      - agynio/api/authorization/v1
       - agynio/api/llm/v1
       - agynio/api/organizations/v1
       - agynio/api/runner/v1

--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -4,7 +4,7 @@ manifests:
   - manifests/agents-orchestrator
 service_account: agents-orchestrator-e2e
 select: |
-  suite_tags=("svc_agents_orchestrator" "smoke")
+  suite_tags=("svc_agents_orchestrator" "svc_runners" "smoke")
 
   if [ -z "${TAGS:-}" ]; then
     echo "${suite_tags[1]}"

--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -7,7 +7,7 @@ select: |
   suite_tags=("svc_agents_orchestrator" "svc_runners" "smoke")
 
   if [ -z "${TAGS:-}" ]; then
-    echo "${suite_tags[1]}"
+    echo "smoke"
     exit 0
   fi
 

--- a/suites/go-core/tests/diagnostics_helpers_test.go
+++ b/suites/go-core/tests/diagnostics_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || smoke)
 
 package tests
 

--- a/suites/go-core/tests/grpc.go
+++ b/suites/go-core/tests/grpc.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || smoke)
 
 package tests
 

--- a/suites/go-core/tests/identity_helpers_test.go
+++ b/suites/go-core/tests/identity_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_runners
+//go:build e2e && svc_runners && !smoke
 
 package tests
 

--- a/suites/go-core/tests/identity_helpers_test.go
+++ b/suites/go-core/tests/identity_helpers_test.go
@@ -1,0 +1,14 @@
+//go:build e2e && svc_runners
+
+package tests
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func withIdentity(ctx context.Context, identityID string) context.Context {
+	md := metadata.New(map[string]string{"x-identity-id": identityID})
+	return metadata.NewOutgoingContext(ctx, md)
+}

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || smoke)
 
 package tests
 

--- a/suites/go-core/tests/runners_helpers_test.go
+++ b/suites/go-core/tests/runners_helpers_test.go
@@ -22,6 +22,8 @@ const (
 	identityTypeAgent       = "agent"
 
 	clusterAdminIdentityID = "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"
+
+	runnerContainerImage = "alpine:3.21"
 )
 
 var authorizationAddr = envOrDefault("AUTHORIZATION_ADDRESS", "authorization:50051")
@@ -66,6 +68,21 @@ func ensureOrganizationMember(t *testing.T, ctx context.Context, authzClient aut
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cleanupCancel()
-		_, _ = authzClient.Write(cleanupCtx, &authorizationv1.WriteRequest{Deletes: []*authorizationv1.TupleKey{tuple}})
+		cleanupCtx = adminContext(cleanupCtx)
+		if _, err := authzClient.Write(cleanupCtx, &authorizationv1.WriteRequest{Deletes: []*authorizationv1.TupleKey{tuple}}); err != nil {
+			t.Logf("cleanup: authorization delete failed for identity %s org %s: %v", identityID, organizationID, err)
+		}
 	})
+}
+
+func runnerDefaultContainers() []*runnersv1.Container {
+	return []*runnersv1.Container{
+		{
+			ContainerId: "main",
+			Name:        "main",
+			Role:        runnersv1.ContainerRole_CONTAINER_ROLE_MAIN,
+			Image:       runnerContainerImage,
+			Status:      runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
+		},
+	}
 }

--- a/suites/go-core/tests/runners_helpers_test.go
+++ b/suites/go-core/tests/runners_helpers_test.go
@@ -1,0 +1,71 @@
+//go:build e2e && (svc_runners || smoke)
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	authorizationv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/authorization/v1"
+	runnersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runners/v1"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	authorizationIdentityPrefix     = "identity:"
+	authorizationOrganizationPrefix = "organization:"
+	authorizationMemberRelation     = "member"
+
+	identityMetadataKey     = "x-identity-id"
+	identityTypeMetadataKey = "x-identity-type"
+	identityTypeUser        = "user"
+	identityTypeAgent       = "agent"
+
+	clusterAdminIdentityID = "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"
+)
+
+var authorizationAddr = envOrDefault("AUTHORIZATION_ADDRESS", "authorization:50051")
+
+func newRunnerClient(t *testing.T) runnersv1.RunnersServiceClient {
+	t.Helper()
+	conn := dialGRPC(t, runnersAddr)
+	return runnersv1.NewRunnersServiceClient(conn)
+}
+
+func newAuthorizationClient(t *testing.T) authorizationv1.AuthorizationServiceClient {
+	t.Helper()
+	conn := dialGRPC(t, authorizationAddr)
+	return authorizationv1.NewAuthorizationServiceClient(conn)
+}
+
+func contextWithIdentity(ctx context.Context, identityID string, identityType string) context.Context {
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		identityMetadataKey, identityID,
+		identityTypeMetadataKey, identityType,
+	))
+}
+
+func adminContext(ctx context.Context) context.Context {
+	return contextWithIdentity(ctx, clusterAdminIdentityID, identityTypeUser)
+}
+
+func agentContext(ctx context.Context, agentID string) context.Context {
+	return contextWithIdentity(ctx, agentID, identityTypeAgent)
+}
+
+func ensureOrganizationMember(t *testing.T, ctx context.Context, authzClient authorizationv1.AuthorizationServiceClient, identityID string, organizationID string) {
+	t.Helper()
+	tuple := &authorizationv1.TupleKey{
+		User:     authorizationIdentityPrefix + identityID,
+		Relation: authorizationMemberRelation,
+		Object:   authorizationOrganizationPrefix + organizationID,
+	}
+	if _, err := authzClient.Write(ctx, &authorizationv1.WriteRequest{Writes: []*authorizationv1.TupleKey{tuple}}); err != nil {
+		t.Fatalf("authorization write failed: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cleanupCancel()
+		_, _ = authzClient.Write(cleanupCtx, &authorizationv1.WriteRequest{Deletes: []*authorizationv1.TupleKey{tuple}})
+	})
+}

--- a/suites/go-core/tests/runners_sampled_at_test.go
+++ b/suites/go-core/tests/runners_sampled_at_test.go
@@ -1,0 +1,378 @@
+//go:build e2e && svc_runners
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runnersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runners/v1"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestBatchUpdateWorkloadSampledAtSingle(t *testing.T) {
+	runnerClient := newRunnerClient(t)
+	authzClient := newAuthorizationClient(t)
+	ctx, runnerID := setupRunnerFixture(t, runnerClient)
+
+	threadID := uuid.NewString()
+	agentID := uuid.NewString()
+	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, authzClient, clusterAdminIdentityID, organizationID)
+
+	workloadID := uuid.NewString()
+	createRunnerWorkload(t, ctx, runnerClient, workloadID, runnerID, threadID, agentID, organizationID)
+	cleanupRunnerWorkload(t, runnerClient, workloadID)
+
+	sampledAt := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := runnerClient.BatchUpdateWorkloadSampledAt(ctx, &runnersv1.BatchUpdateWorkloadSampledAtRequest{
+		Entries: []*runnersv1.SampledAtEntry{{
+			Id:        workloadID,
+			SampledAt: timestamppb.New(sampledAt),
+		}},
+	}); err != nil {
+		t.Fatalf("BatchUpdateWorkloadSampledAt failed: %v", err)
+	}
+
+	assertRunnerWorkloadSampledAt(t, ctx, runnerClient, workloadID, sampledAt)
+}
+
+func TestBatchUpdateWorkloadSampledAtMultiple(t *testing.T) {
+	runnerClient := newRunnerClient(t)
+	authzClient := newAuthorizationClient(t)
+	ctx, runnerID := setupRunnerFixture(t, runnerClient)
+
+	threadID := uuid.NewString()
+	agentID := uuid.NewString()
+	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, authzClient, clusterAdminIdentityID, organizationID)
+
+	workloadIDs := []string{uuid.NewString(), uuid.NewString()}
+	for _, workloadID := range workloadIDs {
+		createRunnerWorkload(t, ctx, runnerClient, workloadID, runnerID, threadID, agentID, organizationID)
+		cleanupRunnerWorkload(t, runnerClient, workloadID)
+	}
+
+	baseTime := time.Now().UTC().Truncate(time.Microsecond)
+	workloadTimes := []time.Time{baseTime, baseTime.Add(2 * time.Minute)}
+
+	entries := make([]*runnersv1.SampledAtEntry, 0, len(workloadIDs))
+	for i, workloadID := range workloadIDs {
+		entries = append(entries, &runnersv1.SampledAtEntry{
+			Id:        workloadID,
+			SampledAt: timestamppb.New(workloadTimes[i]),
+		})
+	}
+
+	if _, err := runnerClient.BatchUpdateWorkloadSampledAt(ctx, &runnersv1.BatchUpdateWorkloadSampledAtRequest{
+		Entries: entries,
+	}); err != nil {
+		t.Fatalf("BatchUpdateWorkloadSampledAt failed: %v", err)
+	}
+
+	for i, workloadID := range workloadIDs {
+		assertRunnerWorkloadSampledAt(t, ctx, runnerClient, workloadID, workloadTimes[i])
+	}
+}
+
+func TestBatchUpdateWorkloadSampledAtIdempotent(t *testing.T) {
+	runnerClient := newRunnerClient(t)
+	authzClient := newAuthorizationClient(t)
+	ctx, runnerID := setupRunnerFixture(t, runnerClient)
+
+	threadID := uuid.NewString()
+	agentID := uuid.NewString()
+	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, authzClient, clusterAdminIdentityID, organizationID)
+
+	workloadID := uuid.NewString()
+	createRunnerWorkload(t, ctx, runnerClient, workloadID, runnerID, threadID, agentID, organizationID)
+	cleanupRunnerWorkload(t, runnerClient, workloadID)
+
+	sampledAt := time.Now().UTC().Truncate(time.Microsecond)
+	req := &runnersv1.BatchUpdateWorkloadSampledAtRequest{
+		Entries: []*runnersv1.SampledAtEntry{{
+			Id:        workloadID,
+			SampledAt: timestamppb.New(sampledAt),
+		}},
+	}
+
+	if _, err := runnerClient.BatchUpdateWorkloadSampledAt(ctx, req); err != nil {
+		t.Fatalf("BatchUpdateWorkloadSampledAt failed: %v", err)
+	}
+	if _, err := runnerClient.BatchUpdateWorkloadSampledAt(ctx, req); err != nil {
+		t.Fatalf("BatchUpdateWorkloadSampledAt idempotent failed: %v", err)
+	}
+
+	assertRunnerWorkloadSampledAt(t, ctx, runnerClient, workloadID, sampledAt)
+}
+
+func TestBatchUpdateVolumeSampledAtSingle(t *testing.T) {
+	runnerClient := newRunnerClient(t)
+	authzClient := newAuthorizationClient(t)
+	ctx, runnerID := setupRunnerFixture(t, runnerClient)
+
+	threadID := uuid.NewString()
+	agentID := uuid.NewString()
+	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, authzClient, clusterAdminIdentityID, organizationID)
+
+	volumeID := uuid.NewString()
+	volumeExternalID := uuid.NewString()
+	createRunnerVolume(t, ctx, runnerClient, volumeID, volumeExternalID, runnerID, threadID, agentID, organizationID)
+	cleanupRunnerVolume(t, runnerClient, volumeID)
+
+	sampledAt := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := runnerClient.BatchUpdateVolumeSampledAt(ctx, &runnersv1.BatchUpdateVolumeSampledAtRequest{
+		Entries: []*runnersv1.SampledAtEntry{{
+			Id:        volumeID,
+			SampledAt: timestamppb.New(sampledAt),
+		}},
+	}); err != nil {
+		t.Fatalf("BatchUpdateVolumeSampledAt failed: %v", err)
+	}
+
+	assertRunnerVolumeSampledAt(t, ctx, runnerClient, volumeID, sampledAt)
+}
+
+func TestBatchUpdateVolumeSampledAtMultiple(t *testing.T) {
+	runnerClient := newRunnerClient(t)
+	authzClient := newAuthorizationClient(t)
+	ctx, runnerID := setupRunnerFixture(t, runnerClient)
+
+	threadID := uuid.NewString()
+	agentID := uuid.NewString()
+	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, authzClient, clusterAdminIdentityID, organizationID)
+
+	volumeIDs := []string{uuid.NewString(), uuid.NewString()}
+	volumeExternalIDs := []string{uuid.NewString(), uuid.NewString()}
+	for i, volumeID := range volumeIDs {
+		createRunnerVolume(t, ctx, runnerClient, volumeID, volumeExternalIDs[i], runnerID, threadID, agentID, organizationID)
+		cleanupRunnerVolume(t, runnerClient, volumeID)
+	}
+
+	baseTime := time.Now().UTC().Truncate(time.Microsecond)
+	volumeTimes := []time.Time{baseTime.Add(3 * time.Minute), baseTime.Add(5 * time.Minute)}
+
+	entries := make([]*runnersv1.SampledAtEntry, 0, len(volumeIDs))
+	for i, volumeID := range volumeIDs {
+		entries = append(entries, &runnersv1.SampledAtEntry{
+			Id:        volumeID,
+			SampledAt: timestamppb.New(volumeTimes[i]),
+		})
+	}
+
+	if _, err := runnerClient.BatchUpdateVolumeSampledAt(ctx, &runnersv1.BatchUpdateVolumeSampledAtRequest{
+		Entries: entries,
+	}); err != nil {
+		t.Fatalf("BatchUpdateVolumeSampledAt failed: %v", err)
+	}
+
+	for i, volumeID := range volumeIDs {
+		assertRunnerVolumeSampledAt(t, ctx, runnerClient, volumeID, volumeTimes[i])
+	}
+}
+
+func TestBatchUpdateVolumeSampledAtIdempotent(t *testing.T) {
+	runnerClient := newRunnerClient(t)
+	authzClient := newAuthorizationClient(t)
+	ctx, runnerID := setupRunnerFixture(t, runnerClient)
+
+	threadID := uuid.NewString()
+	agentID := uuid.NewString()
+	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, authzClient, clusterAdminIdentityID, organizationID)
+
+	volumeID := uuid.NewString()
+	volumeExternalID := uuid.NewString()
+	createRunnerVolume(t, ctx, runnerClient, volumeID, volumeExternalID, runnerID, threadID, agentID, organizationID)
+	cleanupRunnerVolume(t, runnerClient, volumeID)
+
+	sampledAt := time.Now().UTC().Truncate(time.Microsecond)
+	req := &runnersv1.BatchUpdateVolumeSampledAtRequest{
+		Entries: []*runnersv1.SampledAtEntry{{
+			Id:        volumeID,
+			SampledAt: timestamppb.New(sampledAt),
+		}},
+	}
+
+	if _, err := runnerClient.BatchUpdateVolumeSampledAt(ctx, req); err != nil {
+		t.Fatalf("BatchUpdateVolumeSampledAt failed: %v", err)
+	}
+	if _, err := runnerClient.BatchUpdateVolumeSampledAt(ctx, req); err != nil {
+		t.Fatalf("BatchUpdateVolumeSampledAt idempotent failed: %v", err)
+	}
+
+	assertRunnerVolumeSampledAt(t, ctx, runnerClient, volumeID, sampledAt)
+}
+
+func setupRunnerFixture(t *testing.T, runnerClient runnersv1.RunnersServiceClient) (context.Context, string) {
+	t.Helper()
+	ctx := newRunnerTestContext(t)
+	runnerID := registerRunnerFixture(t, ctx, runnerClient)
+	cleanupRunnerFixture(t, runnerClient, runnerID)
+	return ctx, runnerID
+}
+
+func newRunnerTestContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	t.Cleanup(cancel)
+	return adminContext(ctx)
+}
+
+func cleanupRunnerFixture(t *testing.T, runnerClient runnersv1.RunnersServiceClient, runnerID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
+		_, _ = runnerClient.DeleteRunner(cleanupCtx, &runnersv1.DeleteRunnerRequest{Id: runnerID})
+	})
+}
+
+func cleanupRunnerWorkload(t *testing.T, runnerClient runnersv1.RunnersServiceClient, workloadID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
+		_, _ = runnerClient.DeleteWorkload(cleanupCtx, &runnersv1.DeleteWorkloadRequest{Id: workloadID})
+	})
+}
+
+func cleanupRunnerVolume(t *testing.T, runnerClient runnersv1.RunnersServiceClient, volumeID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
+		_, _ = runnerClient.UpdateVolume(cleanupCtx, &runnersv1.UpdateVolumeRequest{
+			Id:        volumeID,
+			Status:    runnersv1.VolumeStatus_VOLUME_STATUS_DELETED.Enum(),
+			RemovedAt: timestamppb.New(time.Now().UTC()),
+		})
+	})
+}
+
+func assertRunnerWorkloadSampledAt(t *testing.T, ctx context.Context, runnerClient runnersv1.RunnersServiceClient, workloadID string, expected time.Time) {
+	t.Helper()
+	resp, err := runnerClient.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID})
+	if err != nil {
+		t.Fatalf("GetWorkload failed: %v", err)
+	}
+	workload := resp.GetWorkload()
+	if workload == nil {
+		t.Fatal("GetWorkload missing workload")
+	}
+	lastSampledAt := workload.GetLastMeteringSampledAt()
+	if lastSampledAt == nil {
+		t.Fatalf("workload %s missing last_metering_sampled_at (expected %s)", workloadID, expected)
+	}
+	actual := lastSampledAt.AsTime()
+	if !actual.Equal(expected) {
+		t.Fatalf("workload %s sampled_at mismatch: got %s, want %s", workloadID, actual, expected)
+	}
+}
+
+func assertRunnerVolumeSampledAt(t *testing.T, ctx context.Context, runnerClient runnersv1.RunnersServiceClient, volumeID string, expected time.Time) {
+	t.Helper()
+	resp, err := runnerClient.GetVolume(ctx, &runnersv1.GetVolumeRequest{Id: volumeID})
+	if err != nil {
+		t.Fatalf("GetVolume failed: %v", err)
+	}
+	volume := resp.GetVolume()
+	if volume == nil {
+		t.Fatal("GetVolume missing volume")
+	}
+	lastSampledAt := volume.GetLastMeteringSampledAt()
+	if lastSampledAt == nil {
+		t.Fatalf("volume %s missing last_metering_sampled_at (expected %s)", volumeID, expected)
+	}
+	actual := lastSampledAt.AsTime()
+	if !actual.Equal(expected) {
+		t.Fatalf("volume %s sampled_at mismatch: got %s, want %s", volumeID, actual, expected)
+	}
+}
+
+func registerRunnerFixture(t *testing.T, ctx context.Context, runnerClient runnersv1.RunnersServiceClient) string {
+	t.Helper()
+	resp, err := runnerClient.RegisterRunner(ctx, &runnersv1.RegisterRunnerRequest{
+		Name: "e2e-runner-" + uuid.NewString(),
+	})
+	if err != nil {
+		t.Fatalf("RegisterRunner failed: %v", err)
+	}
+	runner := resp.GetRunner()
+	if runner == nil || runner.GetMeta() == nil {
+		t.Fatal("runner metadata missing")
+	}
+	runnerID := runner.GetMeta().GetId()
+	if runnerID == "" {
+		t.Fatal("runner ID missing")
+	}
+	return runnerID
+}
+
+func createRunnerWorkload(t *testing.T, ctx context.Context, runnerClient runnersv1.RunnersServiceClient, workloadID, runnerID, threadID, agentID, organizationID string) {
+	t.Helper()
+	resp, err := runnerClient.CreateWorkload(ctx, &runnersv1.CreateWorkloadRequest{
+		Id:             workloadID,
+		RunnerId:       runnerID,
+		ThreadId:       threadID,
+		AgentId:        agentID,
+		OrganizationId: organizationID,
+		Status:         runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		Containers:     runnerDefaultContainers(),
+		ZitiIdentityId: "ziti-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkload failed: %v", err)
+	}
+	workload := resp.GetWorkload()
+	if workload == nil || workload.GetMeta() == nil {
+		t.Fatal("CreateWorkload missing workload metadata")
+	}
+	if workload.GetMeta().GetId() != workloadID {
+		t.Fatalf("CreateWorkload returned unexpected ID")
+	}
+}
+
+func createRunnerVolume(t *testing.T, ctx context.Context, runnerClient runnersv1.RunnersServiceClient, volumeID, volumeExternalID, runnerID, threadID, agentID, organizationID string) {
+	t.Helper()
+	resp, err := runnerClient.CreateVolume(ctx, &runnersv1.CreateVolumeRequest{
+		Id:             volumeID,
+		VolumeId:       volumeExternalID,
+		ThreadId:       threadID,
+		RunnerId:       runnerID,
+		AgentId:        agentID,
+		OrganizationId: organizationID,
+		SizeGb:         "10",
+		Status:         runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	volume := resp.GetVolume()
+	if volume == nil || volume.GetMeta() == nil {
+		t.Fatal("CreateVolume missing volume metadata")
+	}
+	if volume.GetMeta().GetId() != volumeID {
+		t.Fatalf("CreateVolume returned unexpected ID")
+	}
+}
+
+func runnerDefaultContainers() []*runnersv1.Container {
+	return []*runnersv1.Container{
+		{
+			ContainerId: "main",
+			Name:        "main",
+			Role:        runnersv1.ContainerRole_CONTAINER_ROLE_MAIN,
+			Image:       "alpine:latest",
+			Status:      runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
+		},
+	}
+}

--- a/suites/go-core/tests/runners_sampled_at_test.go
+++ b/suites/go-core/tests/runners_sampled_at_test.go
@@ -364,15 +364,3 @@ func createRunnerVolume(t *testing.T, ctx context.Context, runnerClient runnersv
 		t.Fatalf("CreateVolume returned unexpected ID")
 	}
 }
-
-func runnerDefaultContainers() []*runnersv1.Container {
-	return []*runnersv1.Container{
-		{
-			ContainerId: "main",
-			Name:        "main",
-			Role:        runnersv1.ContainerRole_CONTAINER_ROLE_MAIN,
-			Image:       "alpine:latest",
-			Status:      runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
-		},
-	}
-}

--- a/suites/go-core/tests/runners_test.go
+++ b/suites/go-core/tests/runners_test.go
@@ -1,0 +1,189 @@
+//go:build e2e && (svc_runners || smoke)
+
+package tests
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	runnersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runners/v1"
+	"github.com/google/uuid"
+)
+
+func TestRunnerLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	t.Cleanup(cancel)
+	adminCtx := adminContext(ctx)
+
+	runnerClient := newRunnerClient(t)
+	authzClient := newAuthorizationClient(t)
+
+	registerLabels := map[string]string{
+		"region": "test",
+		"tier":   "e2e",
+	}
+	registerResp, err := runnerClient.RegisterRunner(adminCtx, &runnersv1.RegisterRunnerRequest{
+		Name:   "e2e-runner",
+		Labels: registerLabels,
+	})
+	if err != nil {
+		t.Fatalf("RegisterRunner failed: %v", err)
+	}
+
+	runner := registerResp.GetRunner()
+	if runner == nil || runner.GetMeta() == nil {
+		t.Fatal("runner metadata missing")
+	}
+	runnerID := runner.GetMeta().GetId()
+	if runnerID == "" {
+		t.Fatal("runner ID missing")
+	}
+	if !reflect.DeepEqual(runner.GetLabels(), registerLabels) {
+		t.Fatalf("RegisterRunner returned unexpected labels")
+	}
+	token := registerResp.GetServiceToken()
+	if token == "" {
+		t.Fatal("service token missing")
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
+		_, _ = runnerClient.DeleteRunner(cleanupCtx, &runnersv1.DeleteRunnerRequest{Id: runnerID})
+	})
+
+	validateResp, err := runnerClient.ValidateServiceToken(adminCtx, &runnersv1.ValidateServiceTokenRequest{
+		TokenHash: token,
+	})
+	if err != nil {
+		t.Fatalf("ValidateServiceToken failed: %v", err)
+	}
+	if validateResp.GetRunner().GetMeta().GetId() != runnerID {
+		t.Fatalf("ValidateServiceToken returned unexpected runner ID")
+	}
+
+	workloadID := uuid.NewString()
+	threadID := uuid.NewString()
+	agentID := uuid.NewString()
+	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, adminCtx, authzClient, clusterAdminIdentityID, organizationID)
+
+	createResp, err := runnerClient.CreateWorkload(adminCtx, &runnersv1.CreateWorkloadRequest{
+		Id:             workloadID,
+		RunnerId:       runnerID,
+		ThreadId:       threadID,
+		AgentId:        agentID,
+		OrganizationId: organizationID,
+		Status:         runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
+		Containers: []*runnersv1.Container{
+			{
+				ContainerId: "main",
+				Name:        "main",
+				Role:        runnersv1.ContainerRole_CONTAINER_ROLE_MAIN,
+				Image:       "alpine:latest",
+				Status:      runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
+			},
+		},
+		ZitiIdentityId: "ziti-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkload failed: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
+		_, _ = runnerClient.DeleteWorkload(cleanupCtx, &runnersv1.DeleteWorkloadRequest{Id: workloadID})
+	})
+
+	if createResp.GetWorkload().GetMeta().GetId() != workloadID {
+		t.Fatalf("CreateWorkload returned unexpected ID")
+	}
+
+	updateResp, err := runnerClient.UpdateWorkloadStatus(adminCtx, &runnersv1.UpdateWorkloadStatusRequest{
+		Id:     workloadID,
+		Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		Containers: []*runnersv1.Container{
+			{
+				ContainerId: "main",
+				Name:        "main",
+				Role:        runnersv1.ContainerRole_CONTAINER_ROLE_MAIN,
+				Image:       "alpine:latest",
+				Status:      runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateWorkloadStatus failed: %v", err)
+	}
+	if updateResp.GetWorkload().GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+		t.Fatalf("UpdateWorkloadStatus did not return running status")
+	}
+
+	agentCtx := agentContext(ctx, agentID)
+	if _, err := runnerClient.TouchWorkload(agentCtx, &runnersv1.TouchWorkloadRequest{Id: workloadID}); err != nil {
+		t.Fatalf("TouchWorkload failed: %v", err)
+	}
+
+	getResp, err := runnerClient.GetWorkload(adminCtx, &runnersv1.GetWorkloadRequest{Id: workloadID})
+	if err != nil {
+		t.Fatalf("GetWorkload failed: %v", err)
+	}
+	if getResp.GetWorkload().GetThreadId() != threadID {
+		t.Fatalf("GetWorkload returned unexpected thread ID")
+	}
+
+	listByThreadResp, err := runnerClient.ListWorkloadsByThread(adminCtx, &runnersv1.ListWorkloadsByThreadRequest{
+		ThreadId:  threadID,
+		PageSize:  10,
+		PageToken: "",
+	})
+	if err != nil {
+		t.Fatalf("ListWorkloadsByThread failed: %v", err)
+	}
+	if !containsRunnerWorkload(listByThreadResp.GetWorkloads(), workloadID) {
+		t.Fatalf("ListWorkloadsByThread missing workload")
+	}
+
+	listResp, err := runnerClient.ListWorkloads(adminCtx, &runnersv1.ListWorkloadsRequest{
+		PageSize: 10,
+		Statuses: []runnersv1.WorkloadStatus{runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+	})
+	if err != nil {
+		t.Fatalf("ListWorkloads failed: %v", err)
+	}
+	if !containsRunnerWorkload(listResp.GetWorkloads(), workloadID) {
+		t.Fatalf("ListWorkloads missing workload")
+	}
+
+	if _, err := runnerClient.DeleteWorkload(adminCtx, &runnersv1.DeleteWorkloadRequest{Id: workloadID}); err != nil {
+		t.Fatalf("DeleteWorkload failed: %v", err)
+	}
+
+	deletedResp, err := runnerClient.GetWorkload(adminCtx, &runnersv1.GetWorkloadRequest{Id: workloadID})
+	if err != nil {
+		t.Fatalf("GetWorkload after delete failed: %v", err)
+	}
+	if deletedResp.GetWorkload().GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED {
+		t.Fatalf("expected stopped status after delete")
+	}
+	if deletedResp.GetWorkload().GetRemovedAt() == nil {
+		t.Fatalf("expected removed_at after delete")
+	}
+
+	if _, err := runnerClient.DeleteRunner(adminCtx, &runnersv1.DeleteRunnerRequest{Id: runnerID}); err != nil {
+		t.Fatalf("DeleteRunner failed: %v", err)
+	}
+}
+
+func containsRunnerWorkload(workloads []*runnersv1.Workload, workloadID string) bool {
+	for _, workload := range workloads {
+		if workload.GetMeta().GetId() == workloadID {
+			return true
+		}
+	}
+	return false
+}

--- a/suites/go-core/tests/runners_test.go
+++ b/suites/go-core/tests/runners_test.go
@@ -24,7 +24,7 @@ func TestRunnerLifecycle(t *testing.T) {
 		"tier":   "e2e",
 	}
 	registerResp, err := runnerClient.RegisterRunner(adminCtx, &runnersv1.RegisterRunnerRequest{
-		Name:   "e2e-runner",
+		Name:   "e2e-runner-" + uuid.NewString(),
 		Labels: registerLabels,
 	})
 	if err != nil {
@@ -77,15 +77,7 @@ func TestRunnerLifecycle(t *testing.T) {
 		AgentId:        agentID,
 		OrganizationId: organizationID,
 		Status:         runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
-		Containers: []*runnersv1.Container{
-			{
-				ContainerId: "main",
-				Name:        "main",
-				Role:        runnersv1.ContainerRole_CONTAINER_ROLE_MAIN,
-				Image:       "alpine:latest",
-				Status:      runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
-			},
-		},
+		Containers:     runnerDefaultContainers(),
 		ZitiIdentityId: "ziti-test",
 	})
 	if err != nil {
@@ -104,17 +96,9 @@ func TestRunnerLifecycle(t *testing.T) {
 	}
 
 	updateResp, err := runnerClient.UpdateWorkloadStatus(adminCtx, &runnersv1.UpdateWorkloadStatusRequest{
-		Id:     workloadID,
-		Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
-		Containers: []*runnersv1.Container{
-			{
-				ContainerId: "main",
-				Name:        "main",
-				Role:        runnersv1.ContainerRole_CONTAINER_ROLE_MAIN,
-				Image:       "alpine:latest",
-				Status:      runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
-			},
-		},
+		Id:         workloadID,
+		Status:     runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		Containers: runnerDefaultContainers(),
 	})
 	if err != nil {
 		t.Fatalf("UpdateWorkloadStatus failed: %v", err)


### PR DESCRIPTION
## Summary
- migrate runners E2E coverage into go-core with svc_runners/smoke tags
- add go-core buf/module configuration and diagnostics helpers for the suite
- update go-core runner to generate protos and emit junit.xml

## Testing
- go test -count=1 -tags \"e2e smoke svc_runners\" -run TestNonExistent ./tests/...
- go vet -tags \"e2e smoke svc_runners\" ./tests/...

## Issue
- #9