### PR TITLE
feat(go-core): add metering e2e

### DIFF
--- a/suites/go-core/buf.gen.yaml
+++ b/suites/go-core/buf.gen.yaml
@@ -12,6 +12,7 @@ inputs:
       - agynio/api/agents/v1
       - agynio/api/authorization/v1
       - agynio/api/llm/v1
+      - agynio/api/metering/v1
       - agynio/api/organizations/v1
       - agynio/api/runner/v1
       - agynio/api/runners/v1

--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -4,7 +4,7 @@ manifests:
   - manifests/agents-orchestrator
 service_account: agents-orchestrator-e2e
 select: |
-  suite_tags=("svc_agents_orchestrator" "svc_runners" "smoke")
+  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "smoke")
 
   if [ -z "${TAGS:-}" ]; then
     echo "smoke"

--- a/suites/go-core/tests/grpc.go
+++ b/suites/go-core/tests/grpc.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || smoke)
 
 package tests
 

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || smoke)
 
 package tests
 
@@ -50,6 +50,7 @@ var (
 	agentsAddr     = envOrDefault("AGENTS_ADDRESS", "agents:50051")
 	threadsAddr    = envOrDefault("THREADS_ADDRESS", "threads:50051")
 	llmAddr        = envOrDefault("LLM_ADDRESS", "llm:50051")
+	meteringAddr   = envOrDefault("METERING_ADDRESS", "metering:50051")
 	usersAddr      = envOrDefault("USERS_ADDRESS", "users:50051")
 	orgsAddr       = envOrDefault("ORGANIZATIONS_ADDRESS", "organizations:50051")
 	runnerAddr     = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")

--- a/suites/go-core/tests/metering_helpers_test.go
+++ b/suites/go-core/tests/metering_helpers_test.go
@@ -1,0 +1,15 @@
+//go:build e2e && (svc_metering || smoke)
+
+package tests
+
+import (
+	"testing"
+
+	meteringv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/metering/v1"
+)
+
+func newMeteringClient(t *testing.T) meteringv1.MeteringServiceClient {
+	t.Helper()
+	conn := dialGRPC(t, meteringAddr)
+	return meteringv1.NewMeteringServiceClient(conn)
+}

--- a/suites/go-core/tests/metering_test.go
+++ b/suites/go-core/tests/metering_test.go
@@ -1,0 +1,114 @@
+//go:build e2e && (svc_metering || smoke)
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	meteringv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/metering/v1"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestRecordAndQueryUsage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	client := newMeteringClient(t)
+
+	orgID := uuid.NewString()
+	resourceID := uuid.NewString()
+	identityID := uuid.NewString()
+	threadID := uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	records := []*meteringv1.UsageRecord{
+		{
+			OrgId:          orgID,
+			IdempotencyKey: uuid.NewString() + "-input",
+			Producer:       "e2e",
+			Timestamp:      timestamppb.New(now),
+			Labels: map[string]string{
+				"resource_id":   resourceID,
+				"resource":      "model",
+				"identity_id":   identityID,
+				"identity_type": "user",
+				"thread_id":     threadID,
+				"kind":          "input",
+				"status":        "success",
+			},
+			Unit:  meteringv1.Unit_UNIT_TOKENS,
+			Value: 1_500_000,
+		},
+		{
+			OrgId:          orgID,
+			IdempotencyKey: uuid.NewString() + "-output",
+			Producer:       "e2e",
+			Timestamp:      timestamppb.New(now),
+			Labels: map[string]string{
+				"resource_id":   resourceID,
+				"resource":      "model",
+				"identity_id":   identityID,
+				"identity_type": "user",
+				"thread_id":     threadID,
+				"kind":          "output",
+				"status":        "success",
+			},
+			Unit:  meteringv1.Unit_UNIT_TOKENS,
+			Value: 2_500_000,
+		},
+	}
+
+	if _, err := client.Record(ctx, &meteringv1.RecordRequest{Records: records}); err != nil {
+		t.Fatalf("record usage: %v", err)
+	}
+
+	start := timestamppb.New(now.Add(-time.Minute))
+	end := timestamppb.New(now.Add(time.Minute))
+
+	grouped, err := client.QueryUsage(ctx, &meteringv1.QueryUsageRequest{
+		OrgId:       orgID,
+		Start:       start,
+		End:         end,
+		Unit:        meteringv1.Unit_UNIT_TOKENS,
+		GroupBy:     "kind",
+		Granularity: meteringv1.Granularity_GRANULARITY_TOTAL,
+	})
+	if err != nil {
+		t.Fatalf("query grouped usage: %v", err)
+	}
+	if len(grouped.Buckets) != 2 {
+		t.Fatalf("expected 2 buckets, got %d", len(grouped.Buckets))
+	}
+
+	values := map[string]int64{}
+	for _, bucket := range grouped.Buckets {
+		values[bucket.GetGroupValue()] = bucket.GetValue()
+	}
+	if values["input"] != records[0].Value {
+		t.Fatalf("expected input value %d, got %d", records[0].Value, values["input"])
+	}
+	if values["output"] != records[1].Value {
+		t.Fatalf("expected output value %d, got %d", records[1].Value, values["output"])
+	}
+
+	filtered, err := client.QueryUsage(ctx, &meteringv1.QueryUsageRequest{
+		OrgId:        orgID,
+		Start:        start,
+		End:          end,
+		Unit:         meteringv1.Unit_UNIT_TOKENS,
+		LabelFilters: map[string]string{"kind": "input"},
+		Granularity:  meteringv1.Granularity_GRANULARITY_TOTAL,
+	})
+	if err != nil {
+		t.Fatalf("query filtered usage: %v", err)
+	}
+	if len(filtered.Buckets) != 1 {
+		t.Fatalf("expected 1 bucket, got %d", len(filtered.Buckets))
+	}
+	if filtered.Buckets[0].Value != records[0].Value {
+		t.Fatalf("expected filtered value %d, got %d", records[0].Value, filtered.Buckets[0].Value)
+	}
+}


### PR DESCRIPTION
## Summary
- add metering svc_metering coverage to the go-core suite
- include metering proto generation input and suite tag selection

## Testing
- buf generate
- go test -count=1 -tags "e2e smoke svc_metering" -run TestNonExistent ./tests/...
- go vet -tags "e2e smoke svc_metering" ./tests/...

Closes #11