### PR TITLE
feat(go-core): add k8s-runner e2e

### DIFF
--- a/suites/go-core/go.mod
+++ b/suites/go-core/go.mod
@@ -4,6 +4,7 @@ go 1.25
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
@@ -32,6 +33,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -4,7 +4,7 @@ manifests:
   - manifests/agents-orchestrator
 service_account: agents-orchestrator-e2e
 select: |
-  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "smoke")
+  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "smoke")
 
   if [ -z "${TAGS:-}" ]; then
     echo "smoke"

--- a/suites/go-core/tests/grpc.go
+++ b/suites/go-core/tests/grpc.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || smoke)
 
 package tests
 

--- a/suites/go-core/tests/k8s_runner_errors_test.go
+++ b/suites/go-core/tests/k8s_runner_errors_test.go
@@ -1,0 +1,73 @@
+//go:build e2e && svc_k8s_runner
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
+)
+
+func TestErrors(t *testing.T) {
+	client := newK8sRunnerClient(t)
+
+	t.Run("start_workload_missing_image", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		_, err := client.StartWorkload(ctx, &runnerv1.StartWorkloadRequest{
+			Main: &runnerv1.ContainerSpec{Image: ""},
+		})
+		requireGRPCCode(t, err, codes.InvalidArgument)
+	})
+
+	t.Run("inspect_nonexistent_workload", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		_, err := client.InspectWorkload(ctx, &runnerv1.InspectWorkloadRequest{WorkloadId: "missing-workload"})
+		requireGRPCCode(t, err, codes.NotFound)
+	})
+
+	t.Run("stream_logs_missing_container_name", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		stream, err := client.StreamWorkloadLogs(ctx, &runnerv1.StreamWorkloadLogsRequest{WorkloadId: "missing-workload"})
+		require.NoError(t, err)
+
+		_, err = stream.Recv()
+		requireGRPCCode(t, err, codes.InvalidArgument)
+	})
+
+	t.Run("exec_on_nonexistent_workload", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		stream, err := client.Exec(ctx)
+		require.NoError(t, err)
+
+		err = stream.Send(&runnerv1.ExecRequest{Msg: &runnerv1.ExecRequest_Start{Start: &runnerv1.ExecStartRequest{
+			TargetId:    "missing-workload",
+			CommandArgv: []string{"echo", "hi"},
+		}}})
+		require.NoError(t, err)
+
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+		errResp := resp.GetError()
+		require.NotNil(t, errResp)
+		require.Equal(t, "exec_start_failed", errResp.GetCode())
+	})
+
+	t.Run("remove_nonexistent_volume", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		_, err := client.RemoveVolume(ctx, &runnerv1.RemoveVolumeRequest{VolumeName: "missing-volume"})
+		requireGRPCCode(t, err, codes.NotFound)
+	})
+}

--- a/suites/go-core/tests/k8s_runner_exec_test.go
+++ b/suites/go-core/tests/k8s_runner_exec_test.go
@@ -1,0 +1,168 @@
+//go:build e2e && svc_k8s_runner
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
+)
+
+func TestExec(t *testing.T) {
+	client := newK8sRunnerClient(t)
+
+	t.Run("basic_command", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		targetID := startRunningWorkloadTarget(t, ctx, client)
+		result := collectExecOutput(t, ctx, client, &runnerv1.ExecStartRequest{
+			TargetId:    targetID,
+			CommandArgv: []string{"echo", "hello-e2e"},
+		})
+
+		require.NotNil(t, result.exit)
+		require.Equal(t, int32(0), result.exit.GetExitCode())
+		require.Contains(t, result.stdout, "hello-e2e")
+	})
+
+	t.Run("shell_command", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		targetID := startRunningWorkloadTarget(t, ctx, client)
+		result := collectExecOutput(t, ctx, client, &runnerv1.ExecStartRequest{
+			TargetId:     targetID,
+			CommandShell: "echo out; echo err 1>&2",
+			Options:      &runnerv1.ExecOptions{SeparateStderr: true},
+			RequestId:    uniqueName("exec"),
+		})
+
+		require.NotNil(t, result.exit)
+		require.Contains(t, result.stdout, "out")
+		require.Contains(t, result.stderr, "err")
+	})
+
+	t.Run("nonzero_exit_code", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		targetID := startRunningWorkloadTarget(t, ctx, client)
+		result := collectExecOutput(t, ctx, client, &runnerv1.ExecStartRequest{
+			TargetId:     targetID,
+			CommandShell: "exit 42",
+		})
+
+		require.NotNil(t, result.exit)
+		require.Equal(t, int32(42), result.exit.GetExitCode())
+	})
+
+	t.Run("stdin_and_eof", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		targetID := startRunningWorkloadTarget(t, ctx, client)
+		payload := "stdin-e2e\n"
+		result := collectExecOutput(
+			t,
+			ctx,
+			client,
+			&runnerv1.ExecStartRequest{
+				TargetId:    targetID,
+				CommandArgv: []string{"cat"},
+			},
+			&runnerv1.ExecStdin{Data: []byte(payload)},
+			&runnerv1.ExecStdin{Eof: true},
+		)
+
+		require.NotNil(t, result.exit)
+		require.Equal(t, payload, result.stdout)
+	})
+
+	t.Run("cancel_execution", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		targetID := startRunningWorkloadTarget(t, ctx, client)
+		stream, err := client.Exec(ctx)
+		require.NoError(t, err)
+
+		err = stream.Send(&runnerv1.ExecRequest{Msg: &runnerv1.ExecRequest_Start{Start: &runnerv1.ExecStartRequest{
+			TargetId:    targetID,
+			CommandArgv: []string{"sleep", "300"},
+		}}})
+		require.NoError(t, err)
+
+		var execID string
+		for {
+			resp, err := stream.Recv()
+			require.NoError(t, err)
+			if started := resp.GetStarted(); started != nil {
+				execID = started.GetExecutionId()
+				break
+			}
+			if errResp := resp.GetError(); errResp != nil {
+				t.Fatalf("exec error: %s", errResp.GetMessage())
+			}
+		}
+
+		require.NotEmpty(t, execID)
+		cancelResp, err := client.CancelExecution(ctx, &runnerv1.CancelExecutionRequest{
+			ExecutionId: execID,
+			Force:       true,
+		})
+		require.NoError(t, err)
+		require.True(t, cancelResp.GetCancelled())
+
+		var exit *runnerv1.ExecExit
+		for {
+			resp, err := stream.Recv()
+			require.NoError(t, err)
+			if exitResp := resp.GetExit(); exitResp != nil {
+				exit = exitResp
+				break
+			}
+			if errResp := resp.GetError(); errResp != nil {
+				t.Fatalf("exec error: %s", errResp.GetMessage())
+			}
+		}
+
+		require.NotNil(t, exit)
+		require.Equal(t, runnerv1.ExecExitReason_EXEC_EXIT_REASON_CANCELLED, exit.GetReason())
+	})
+
+	t.Run("workdir_and_env", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		targetID := startRunningWorkloadTarget(t, ctx, client)
+		result := collectExecOutput(t, ctx, client, &runnerv1.ExecStartRequest{
+			TargetId:     targetID,
+			CommandShell: "pwd; echo $FOO",
+			Options: &runnerv1.ExecOptions{
+				Workdir: "/tmp",
+				Env: []*runnerv1.EnvVar{{
+					Name:  "FOO",
+					Value: "bar",
+				}},
+			},
+		})
+
+		require.NotNil(t, result.exit)
+		require.Contains(t, result.stdout, "/tmp")
+		require.Contains(t, result.stdout, "bar")
+	})
+}
+
+func startRunningWorkloadTarget(t *testing.T, ctx context.Context, client runnerv1.RunnerServiceClient) string {
+	t.Helper()
+	resp := startWorkloadWithCleanup(t, ctx, client, sleepWorkloadRequest())
+	workloadID := resp.GetId()
+	waitRunning(t, ctx, client, workloadID)
+	targetID := resp.GetContainers().GetMain()
+	require.NotEmpty(t, targetID)
+	return targetID
+}

--- a/suites/go-core/tests/k8s_runner_helpers_test.go
+++ b/suites/go-core/tests/k8s_runner_helpers_test.go
@@ -1,0 +1,264 @@
+//go:build e2e && (svc_k8s_runner || smoke)
+
+package tests
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	defaultWorkloadImage = "alpine:3.19"
+	waitRunningTimeout   = 60 * time.Second
+	waitGoneTimeout      = 30 * time.Second
+	cleanupTimeout       = 30 * time.Second
+)
+
+type execResult struct {
+	stdout  string
+	stderr  string
+	exit    *runnerv1.ExecExit
+	started *runnerv1.ExecStarted
+}
+
+func newK8sRunnerClient(t *testing.T) runnerv1.RunnerServiceClient {
+	t.Helper()
+	conn := dialGRPC(t, runnerAddr)
+	return runnerv1.NewRunnerServiceClient(conn)
+}
+
+func testContext(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), testTimeout)
+}
+
+func startWorkload(t *testing.T, ctx context.Context, client runnerv1.RunnerServiceClient, req *runnerv1.StartWorkloadRequest) string {
+	t.Helper()
+	resp := startWorkloadWithCleanup(t, ctx, client, req)
+	return resp.GetId()
+}
+
+func startWorkloadWithCleanup(t *testing.T, ctx context.Context, client runnerv1.RunnerServiceClient, req *runnerv1.StartWorkloadRequest) *runnerv1.StartWorkloadResponse {
+	t.Helper()
+	resp, err := client.StartWorkload(ctx, req)
+	require.NoError(t, err)
+
+	workloadID := strings.TrimSpace(resp.GetId())
+	require.NotEmpty(t, workloadID)
+	registerWorkloadCleanup(t, client, workloadID)
+
+	return resp
+}
+
+func registerWorkloadCleanup(t *testing.T, client runnerv1.RunnerServiceClient, workloadID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+		defer cancel()
+		_, err := client.RemoveWorkload(ctx, &runnerv1.RemoveWorkloadRequest{
+			WorkloadId:    workloadID,
+			Force:         true,
+			RemoveVolumes: true,
+		})
+		if err == nil {
+			return
+		}
+		if status.Code(err) == codes.NotFound {
+			return
+		}
+		t.Errorf("cleanup remove workload %s: %v", workloadID, err)
+	})
+}
+
+func waitRunning(t *testing.T, ctx context.Context, client runnerv1.RunnerServiceClient, workloadID string) *runnerv1.InspectWorkloadResponse {
+	t.Helper()
+	waitCtx, cancel := context.WithTimeout(ctx, waitRunningTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		resp, err := client.InspectWorkload(waitCtx, &runnerv1.InspectWorkloadRequest{WorkloadId: workloadID})
+		if err == nil {
+			if resp.GetStateRunning() {
+				return resp
+			}
+		} else if status.Code(err) != codes.NotFound {
+			require.NoError(t, err)
+		}
+
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("workload %s not running: %v", workloadID, waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitGone(t *testing.T, ctx context.Context, client runnerv1.RunnerServiceClient, workloadID string) {
+	t.Helper()
+	waitCtx, cancel := context.WithTimeout(ctx, waitGoneTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		_, err := client.InspectWorkload(waitCtx, &runnerv1.InspectWorkloadRequest{WorkloadId: workloadID})
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return
+			}
+			require.NoError(t, err)
+		}
+
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("workload %s still present: %v", workloadID, waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func buildTarWithFile(name, content string) []byte {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}); err != nil {
+		panic(err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		panic(err)
+	}
+	if err := tw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+func collectExecOutput(t *testing.T, ctx context.Context, client runnerv1.RunnerServiceClient, start *runnerv1.ExecStartRequest, stdin ...*runnerv1.ExecStdin) execResult {
+	t.Helper()
+	stream, err := client.Exec(ctx)
+	require.NoError(t, err)
+
+	err = stream.Send(&runnerv1.ExecRequest{Msg: &runnerv1.ExecRequest_Start{Start: start}})
+	require.NoError(t, err)
+
+	for _, input := range stdin {
+		if input == nil {
+			continue
+		}
+		err = stream.Send(&runnerv1.ExecRequest{Msg: &runnerv1.ExecRequest_Stdin{Stdin: input}})
+		require.NoError(t, err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var started *runnerv1.ExecStarted
+
+	for {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+
+		switch event := resp.GetEvent().(type) {
+		case *runnerv1.ExecResponse_Started:
+			started = event.Started
+		case *runnerv1.ExecResponse_Stdout:
+			stdout.Write(event.Stdout.GetData())
+		case *runnerv1.ExecResponse_Stderr:
+			stderr.Write(event.Stderr.GetData())
+		case *runnerv1.ExecResponse_Exit:
+			return execResult{
+				stdout:  stdout.String(),
+				stderr:  stderr.String(),
+				exit:    event.Exit,
+				started: started,
+			}
+		case *runnerv1.ExecResponse_Error:
+			t.Fatalf("exec error: %s", event.Error.GetMessage())
+		default:
+			t.Fatalf("unexpected exec response: %T", event)
+		}
+	}
+}
+
+func collectWorkloadLogs(t *testing.T, ctx context.Context, client runnerv1.RunnerServiceClient, workloadID string, follow bool, tail uint32) string {
+	t.Helper()
+	stream, err := client.StreamWorkloadLogs(ctx, &runnerv1.StreamWorkloadLogsRequest{
+		WorkloadId:    workloadID,
+		ContainerName: "main",
+		Follow:        follow,
+		TailLines:     tail,
+	})
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return output.String()
+		}
+		require.NoError(t, err)
+
+		if chunk := resp.GetChunk(); chunk != nil {
+			output.Write(chunk.GetData())
+			continue
+		}
+		if resp.GetEnd() != nil {
+			return output.String()
+		}
+		if errResp := resp.GetError(); errResp != nil {
+			t.Fatalf("log stream error: %s", errResp.GetMessage())
+		}
+	}
+}
+
+func requireGRPCCode(t *testing.T, err error, code codes.Code) {
+	t.Helper()
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, code, st.Code())
+}
+
+func sleepWorkloadRequest(cmd ...string) *runnerv1.StartWorkloadRequest {
+	args := cmd
+	if len(args) == 0 {
+		args = []string{"sleep", "300"}
+	}
+	return &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{
+			Image: defaultWorkloadImage,
+			Cmd:   append([]string{}, args...),
+		},
+	}
+}
+
+func uniqueName(prefix string) string {
+	base := strings.Trim(prefix, "- ")
+	if base == "" {
+		base = "e2e"
+	}
+	return strings.ToLower(fmt.Sprintf("%s-%s", base, uuid.NewString()))
+}
+
+func podNameFromID(id string) string {
+	return fmt.Sprintf("workload-%s", id)
+}

--- a/suites/go-core/tests/k8s_runner_storage_test.go
+++ b/suites/go-core/tests/k8s_runner_storage_test.go
@@ -1,0 +1,45 @@
+//go:build e2e && svc_k8s_runner
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
+)
+
+func TestPutArchive(t *testing.T) {
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	client := newK8sRunnerClient(t)
+	resp := startWorkloadWithCleanup(t, ctx, client, &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{
+			Image:      defaultWorkloadImage,
+			Entrypoint: "/bin/sh",
+			Cmd:        []string{"-c", "mkdir -p /tmp/e2e && sleep 300"},
+		},
+	})
+	workloadID := resp.GetId()
+	targetID := resp.GetContainers().GetMain()
+	require.NotEmpty(t, targetID)
+	waitRunning(t, ctx, client, workloadID)
+
+	tarPayload := buildTarWithFile("hello.txt", "hello-storage")
+	_, err := client.PutArchive(ctx, &runnerv1.PutArchiveRequest{
+		WorkloadId: workloadID,
+		Path:       "/tmp/e2e",
+		TarPayload: tarPayload,
+	})
+	require.NoError(t, err)
+
+	result := collectExecOutput(t, ctx, client, &runnerv1.ExecStartRequest{
+		TargetId:    targetID,
+		CommandArgv: []string{"cat", "/tmp/e2e/hello.txt"},
+	})
+	require.NotNil(t, result.exit)
+	require.Equal(t, int32(0), result.exit.GetExitCode())
+	require.Contains(t, result.stdout, "hello-storage")
+}

--- a/suites/go-core/tests/k8s_runner_streaming_test.go
+++ b/suites/go-core/tests/k8s_runner_streaming_test.go
@@ -1,0 +1,86 @@
+//go:build e2e && svc_k8s_runner
+
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
+)
+
+func TestStreaming(t *testing.T) {
+	client := newK8sRunnerClient(t)
+
+	t.Run("logs_follow", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := &runnerv1.StartWorkloadRequest{
+			Main: &runnerv1.ContainerSpec{
+				Image:      defaultWorkloadImage,
+				Entrypoint: "/bin/sh",
+				Cmd:        []string{"-c", "echo follow-1; echo follow-2; sleep 2"},
+			},
+		}
+		workloadID := startWorkload(t, ctx, client, req)
+		waitRunning(t, ctx, client, workloadID)
+
+		logs := collectWorkloadLogs(t, ctx, client, workloadID, true, 0)
+		require.Contains(t, logs, "follow-1")
+		require.Contains(t, logs, "follow-2")
+	})
+
+	t.Run("logs_tail", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := &runnerv1.StartWorkloadRequest{
+			Main: &runnerv1.ContainerSpec{
+				Image:      defaultWorkloadImage,
+				Entrypoint: "/bin/sh",
+				Cmd:        []string{"-c", "echo line-1; echo line-2; echo line-3; echo line-4; sleep 2"},
+			},
+		}
+		workloadID := startWorkload(t, ctx, client, req)
+		waitRunning(t, ctx, client, workloadID)
+
+		logs := collectWorkloadLogs(t, ctx, client, workloadID, false, 2)
+		require.Contains(t, logs, "line-3")
+		require.Contains(t, logs, "line-4")
+		require.NotContains(t, logs, "line-1")
+	})
+}
+
+func TestStreamEvents(t *testing.T) {
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	client := newK8sRunnerClient(t)
+	streamCtx, streamCancel := context.WithTimeout(ctx, waitRunningTimeout)
+	t.Cleanup(streamCancel)
+
+	stream, err := client.StreamEvents(streamCtx, &runnerv1.StreamEventsRequest{})
+	require.NoError(t, err)
+
+	workloadID := startWorkload(t, ctx, client, sleepWorkloadRequest())
+	waitRunning(t, ctx, client, workloadID)
+	podName := podNameFromID(workloadID)
+
+	for {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+		if data := resp.GetData(); data != nil {
+			if strings.Contains(data.GetJson(), podName) {
+				return
+			}
+			continue
+		}
+		if errResp := resp.GetError(); errResp != nil {
+			t.Fatalf("events stream error: %s", errResp.GetMessage())
+		}
+	}
+}

--- a/suites/go-core/tests/k8s_runner_volume_test.go
+++ b/suites/go-core/tests/k8s_runner_volume_test.go
@@ -1,0 +1,61 @@
+//go:build e2e && svc_k8s_runner
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
+)
+
+func TestVolumeQueries(t *testing.T) {
+	client := newK8sRunnerClient(t)
+
+	t.Run("list_workloads_by_volume", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		volumeName := uniqueName("volume")
+		workloadID := startWorkload(t, ctx, client, volumeWorkloadRequest(volumeName))
+		waitRunning(t, ctx, client, workloadID)
+
+		resp, err := client.ListWorkloadsByVolume(ctx, &runnerv1.ListWorkloadsByVolumeRequest{VolumeName: volumeName})
+		require.NoError(t, err)
+		require.Contains(t, resp.GetTargetIds(), workloadID)
+	})
+
+	t.Run("remove_volume", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		volumeName := uniqueName("volume")
+		workloadID := startWorkload(t, ctx, client, volumeWorkloadRequest(volumeName))
+		waitRunning(t, ctx, client, workloadID)
+
+		_, err := client.StopWorkload(ctx, &runnerv1.StopWorkloadRequest{WorkloadId: workloadID, TimeoutSec: 1})
+		require.NoError(t, err)
+		waitGone(t, ctx, client, workloadID)
+
+		_, err = client.RemoveVolume(ctx, &runnerv1.RemoveVolumeRequest{VolumeName: volumeName})
+		require.NoError(t, err)
+		_, err = client.RemoveVolume(ctx, &runnerv1.RemoveVolumeRequest{VolumeName: volumeName})
+		requireGRPCCode(t, err, codes.NotFound)
+	})
+}
+
+func volumeWorkloadRequest(volumeName string) *runnerv1.StartWorkloadRequest {
+	req := sleepWorkloadRequest()
+	req.Volumes = []*runnerv1.VolumeSpec{{
+		Name:           "data",
+		Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+		PersistentName: volumeName,
+	}}
+	req.Main.Mounts = []*runnerv1.VolumeMount{{
+		Volume:    "data",
+		MountPath: "/data",
+	}}
+	return req
+}

--- a/suites/go-core/tests/k8s_runner_workload_test.go
+++ b/suites/go-core/tests/k8s_runner_workload_test.go
@@ -1,0 +1,168 @@
+//go:build e2e && (svc_k8s_runner || smoke)
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
+)
+
+func TestReady(t *testing.T) {
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	client := newK8sRunnerClient(t)
+	resp, err := client.Ready(ctx, &runnerv1.ReadyRequest{})
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp.GetStatus())
+}
+
+func TestWorkloadLifecycle(t *testing.T) {
+	client := newK8sRunnerClient(t)
+
+	t.Run("start_and_inspect", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startWorkload(t, ctx, client, sleepWorkloadRequest())
+		resp := waitRunning(t, ctx, client, workloadID)
+
+		require.Equal(t, workloadID, resp.GetId())
+		require.Equal(t, workloadID, resp.GetName())
+		require.Equal(t, defaultWorkloadImage, resp.GetConfigImage())
+		require.NotEmpty(t, resp.GetImage())
+		require.True(t, resp.GetStateRunning())
+		require.NotEmpty(t, resp.GetStateStatus())
+		require.Equal(t, "k8s-runner", resp.GetConfigLabels()["app.kubernetes.io/managed-by"])
+		require.Equal(t, workloadID, resp.GetConfigLabels()["agyn.io/workload-id"])
+		require.Empty(t, resp.GetMounts())
+	})
+
+	t.Run("start_with_env_and_workdir", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := &runnerv1.StartWorkloadRequest{
+			Main: &runnerv1.ContainerSpec{
+				Image:      defaultWorkloadImage,
+				Entrypoint: "/bin/sh",
+				Cmd:        []string{"-c", "echo \"$FOO\"; pwd; sleep 5"},
+				Env: []*runnerv1.EnvVar{{
+					Name:  "FOO",
+					Value: "hello-e2e",
+				}},
+				WorkingDir: "/tmp",
+			},
+		}
+
+		workloadID := startWorkload(t, ctx, client, req)
+		waitRunning(t, ctx, client, workloadID)
+
+		logs := collectWorkloadLogs(t, ctx, client, workloadID, false, 0)
+		require.Contains(t, logs, "hello-e2e")
+		require.Contains(t, logs, "/tmp")
+	})
+
+	t.Run("start_with_sidecars", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := sleepWorkloadRequest()
+		req.Sidecars = []*runnerv1.ContainerSpec{{
+			Name:  "sidecar",
+			Image: defaultWorkloadImage,
+			Cmd:   []string{"sleep", "300"},
+		}}
+		resp := startWorkloadWithCleanup(t, ctx, client, req)
+		waitRunning(t, ctx, client, resp.GetId())
+
+		sidecars := resp.GetContainers().GetSidecars()
+		require.Len(t, sidecars, 1)
+		require.Equal(t, "sidecar", sidecars[0].GetName())
+		require.NotEmpty(t, sidecars[0].GetId())
+	})
+
+	t.Run("start_with_custom_labels", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := sleepWorkloadRequest()
+		req.AdditionalProperties = map[string]string{
+			"label.team": "platform",
+		}
+		workloadID := startWorkload(t, ctx, client, req)
+		waitRunning(t, ctx, client, workloadID)
+
+		labelsResp, err := client.GetWorkloadLabels(ctx, &runnerv1.GetWorkloadLabelsRequest{WorkloadId: workloadID})
+		require.NoError(t, err)
+		require.Equal(t, "platform", labelsResp.GetLabels()["team"])
+
+		findResp, err := client.FindWorkloadsByLabels(ctx, &runnerv1.FindWorkloadsByLabelsRequest{
+			Labels: map[string]string{"team": "platform"},
+			All:    true,
+		})
+		require.NoError(t, err)
+		require.Contains(t, findResp.GetTargetIds(), workloadID)
+	})
+
+	t.Run("touch_workload", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startWorkload(t, ctx, client, sleepWorkloadRequest())
+		waitRunning(t, ctx, client, workloadID)
+
+		_, err := client.TouchWorkload(ctx, &runnerv1.TouchWorkloadRequest{WorkloadId: workloadID})
+		require.NoError(t, err)
+	})
+
+	t.Run("stop_workload", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startWorkload(t, ctx, client, sleepWorkloadRequest())
+		waitRunning(t, ctx, client, workloadID)
+
+		_, err := client.StopWorkload(ctx, &runnerv1.StopWorkloadRequest{
+			WorkloadId: workloadID,
+			TimeoutSec: 1,
+		})
+		require.NoError(t, err)
+		waitGone(t, ctx, client, workloadID)
+	})
+
+	t.Run("remove_workload_with_volumes", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		volumeName := uniqueName("volume")
+		req := sleepWorkloadRequest()
+		req.Volumes = []*runnerv1.VolumeSpec{{
+			Name:           "data",
+			Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+			PersistentName: volumeName,
+		}}
+		req.Main.Mounts = []*runnerv1.VolumeMount{{
+			Volume:    "data",
+			MountPath: "/data",
+		}}
+
+		workloadID := startWorkload(t, ctx, client, req)
+		waitRunning(t, ctx, client, workloadID)
+
+		_, err := client.RemoveWorkload(ctx, &runnerv1.RemoveWorkloadRequest{
+			WorkloadId:    workloadID,
+			Force:         true,
+			RemoveVolumes: true,
+		})
+		require.NoError(t, err)
+		waitGone(t, ctx, client, workloadID)
+
+		_, err = client.RemoveVolume(ctx, &runnerv1.RemoveVolumeRequest{VolumeName: volumeName})
+		requireGRPCCode(t, err, codes.NotFound)
+	})
+}

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || smoke)
 
 package tests
 


### PR DESCRIPTION
## Summary
- migrate k8s-runner E2E coverage into go-core suite with svc_k8s_runner tagging
- add shared helpers and smoke coverage for readiness/lifecycle tests
- update suite selection and build tags to include k8s-runner

## Testing
- go test -count=1 -tags "e2e smoke svc_k8s_runner" -run TestNonExistent ./tests/...
- go vet -tags "e2e smoke svc_k8s_runner" ./tests/...

Closes #12