### PR TITLE
feat(go-core): add organizations e2e

### DIFF
--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -4,7 +4,7 @@ manifests:
   - manifests/agents-orchestrator
 service_account: agents-orchestrator-e2e
 select: |
-  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "smoke")
+  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "svc_organizations" "smoke")
 
   if [ -z "${TAGS:-}" ]; then
     echo "smoke"

--- a/suites/go-core/tests/grpc.go
+++ b/suites/go-core/tests/grpc.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || smoke)
 
 package tests
 

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || smoke)
 
 package tests
 

--- a/suites/go-core/tests/organizations_test.go
+++ b/suites/go-core/tests/organizations_test.go
@@ -1,0 +1,137 @@
+//go:build e2e && (svc_organizations || smoke)
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const listPageSize int32 = 50
+
+func TestOrganizationsServiceE2E(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	t.Cleanup(cancel)
+
+	conn := dialGRPC(t, orgsAddr)
+	client := organizationsv1.NewOrganizationsServiceClient(conn)
+
+	testID := uuid.NewString()
+	identityID := uuid.NewString()
+	identityCtx := identityContext(ctx, identityID)
+
+	organizationResp1, err := client.CreateOrganization(identityCtx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Alpha " + testID})
+	require.NoError(t, err)
+	organization1 := organizationResp1.GetOrganization()
+	require.NotNil(t, organization1)
+	organizationID1 := organization1.GetId()
+	require.NotEmpty(t, organizationID1)
+
+	organizationResp2, err := client.CreateOrganization(identityCtx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Beta " + testID})
+	require.NoError(t, err)
+	organization2 := organizationResp2.GetOrganization()
+	require.NotNil(t, organization2)
+	organizationID2 := organization2.GetId()
+	require.NotEmpty(t, organizationID2)
+
+	getResp, err := client.GetOrganization(ctx, &organizationsv1.GetOrganizationRequest{Id: organizationID1})
+	require.NoError(t, err)
+	require.NotNil(t, getResp.GetOrganization())
+	require.Equal(t, organizationID1, getResp.GetOrganization().GetId())
+
+	updatedOrganizationResp, err := client.UpdateOrganization(ctx, &organizationsv1.UpdateOrganizationRequest{
+		Id:   organizationID1,
+		Name: proto.String("Organization Alpha Updated " + testID),
+	})
+	require.NoError(t, err)
+	updatedOrg := updatedOrganizationResp.GetOrganization()
+	require.NotNil(t, updatedOrg)
+	require.Equal(t, "Organization Alpha Updated "+testID, updatedOrg.GetName())
+
+	listResp, err := client.ListOrganizations(ctx, &organizationsv1.ListOrganizationsRequest{PageSize: 1})
+	require.NoError(t, err)
+	require.NotEmpty(t, listResp.GetOrganizations())
+	require.NotEmpty(t, listResp.GetNextPageToken())
+
+	organizations := listOrganizations(ctx, t, client)
+	require.True(t, hasID(organizations, organizationID1))
+	require.True(t, hasID(organizations, organizationID2))
+
+	accessibleResp, err := client.ListAccessibleOrganizations(ctx, &organizationsv1.ListAccessibleOrganizationsRequest{IdentityId: identityID})
+	require.NoError(t, err)
+	require.True(t, hasID(accessibleResp.GetOrganizations(), organizationID1))
+	require.True(t, hasID(accessibleResp.GetOrganizations(), organizationID2))
+
+	_, err = client.UpdateOrganization(ctx, &organizationsv1.UpdateOrganizationRequest{Id: organizationID1})
+	requireStatusCode(t, err, codes.InvalidArgument)
+
+	_, err = client.GetOrganization(ctx, &organizationsv1.GetOrganizationRequest{Id: uuid.NewString()})
+	requireStatusCode(t, err, codes.NotFound)
+
+	_, err = client.DeleteOrganization(ctx, &organizationsv1.DeleteOrganizationRequest{Id: organizationID2})
+	require.NoError(t, err)
+	_, err = client.DeleteOrganization(ctx, &organizationsv1.DeleteOrganizationRequest{Id: organizationID1})
+	require.NoError(t, err)
+
+	_, err = client.CreateOrganization(ctx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Missing Metadata " + testID})
+	requireStatusCode(t, err, codes.Unauthenticated)
+
+	invalidIdentityCtx := identityContext(ctx, "not-a-uuid")
+	_, err = client.CreateOrganization(invalidIdentityCtx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Invalid Metadata " + testID})
+	requireStatusCode(t, err, codes.Unauthenticated)
+}
+
+func listPaged[T any](t *testing.T, resource string, fetch func(pageToken string) ([]T, string, error)) []T {
+	t.Helper()
+	var items []T
+	pageToken := ""
+	for i := 0; i < 20; i++ {
+		pageItems, nextPageToken, err := fetch(pageToken)
+		require.NoError(t, err)
+		items = append(items, pageItems...)
+		if nextPageToken == "" {
+			return items
+		}
+		pageToken = nextPageToken
+	}
+	t.Fatalf("%s pagination exceeded", resource)
+	return nil
+}
+
+func listOrganizations(ctx context.Context, t *testing.T, client organizationsv1.OrganizationsServiceClient) []*organizationsv1.Organization {
+	return listPaged(t, "organization", func(pageToken string) ([]*organizationsv1.Organization, string, error) {
+		resp, err := client.ListOrganizations(ctx, &organizationsv1.ListOrganizationsRequest{PageSize: listPageSize, PageToken: pageToken})
+		if err != nil {
+			return nil, "", err
+		}
+		return resp.GetOrganizations(), resp.GetNextPageToken(), nil
+	})
+}
+
+func identityContext(ctx context.Context, identityID string) context.Context {
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs("x-identity-id", identityID))
+}
+
+func hasID(items []*organizationsv1.Organization, id string) bool {
+	for _, item := range items {
+		if item.GetId() == id {
+			return true
+		}
+	}
+	return false
+}
+
+func requireStatusCode(t *testing.T, err error, code codes.Code) {
+	t.Helper()
+	statusErr, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, code, statusErr.Code())
+}


### PR DESCRIPTION
## Summary
- migrate organizations E2E coverage into go-core suite with svc_organizations tagging
- reuse go-core gRPC helpers and update suite selection/build tags
- add paging/identity helpers aligned with organizations service flows

## Testing
- go test -count=1 -tags "e2e smoke svc_organizations" -run TestNonExistent ./tests/...
- go vet -tags "e2e smoke svc_organizations" ./tests/...

Closes #13