### PR TITLE
chore: bump agn init image

### DIFF
--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -36,7 +36,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.12")
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.13")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -58,7 +58,7 @@ var (
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
 	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.18")
-	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.12")
+	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.13")
 )
 
 type pipelineRun struct {


### PR DESCRIPTION
## Summary
- update AGN init defaults to agent-init-agn:0.4.13

## Testing
- go vet ./... (suites/go-core)
- go test ./... (suites/go-core)
- go vet ./... (suites/go-terraform)
- go test ./... (suites/go-terraform)

## References
- agynio/agents-orchestrator#157
- changes/2026-04-24-home-workspace-env.md