### PR TITLE
test: add username invite e2e coverage

### DIFF
--- a/suites/playwright/test/e2e/mock-server.mjs
+++ b/suites/playwright/test/e2e/mock-server.mjs
@@ -1,6 +1,6 @@
 import http from 'node:http';
 import http2 from 'node:http2';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { BinaryReader, WireType } from '@bufbuild/protobuf/wire';
 
 const port = Number(process.env.MOCK_SERVER_PORT ?? 5000);
@@ -16,6 +16,8 @@ const envScript = `window.__ENV__ = {\n` +
   `};\n`;
 const defaultUserId = 'user-1';
 const defaultEmail = 'e2e-tester@agyn.test';
+const USERNAME_MAX_LENGTH = 32;
+const USERNAME_PATTERN = /^[a-z0-9_-]+$/;
 
 const users = new Map();
 const organizations = new Map();
@@ -237,10 +239,55 @@ function isClusterAdmin(identityId) {
   return users.get(identityId)?.clusterRole === 'CLUSTER_ROLE_ADMIN';
 }
 
-function deriveUsername(input, fallbackId) {
-  const candidate =
-    input.username ?? input.nickname ?? input.email?.split('@')[0] ?? input.name ?? `user-${fallbackId}`;
-  return String(candidate).trim() || `user-${fallbackId}`;
+function normalizeUsernameCandidate(value) {
+  if (!value) return '';
+  const lower = String(value).toLowerCase();
+  let normalized = '';
+  let lastDash = false;
+  for (const char of lower) {
+    const isAllowed =
+      (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char === '_' || char === '-';
+    if (!isAllowed) {
+      if (!lastDash) {
+        normalized += '-';
+        lastDash = true;
+      }
+      continue;
+    }
+    if (char === '-') {
+      if (lastDash) {
+        continue;
+      }
+      lastDash = true;
+      normalized += char;
+      continue;
+    }
+    lastDash = false;
+    normalized += char;
+  }
+  normalized = normalized.replace(/^-+|-+$/g, '');
+  if (normalized.length > USERNAME_MAX_LENGTH) {
+    normalized = normalized.slice(0, USERNAME_MAX_LENGTH);
+  }
+  return normalized;
+}
+
+function fallbackUsername(seed) {
+  const hash = createHash('sha256').update(String(seed ?? '')).digest('hex');
+  return `user-${hash.slice(0, 8)}`;
+}
+
+function validateUsername(value) {
+  if (!value) return 'value is required';
+  if (value.length > USERNAME_MAX_LENGTH) return `max length ${USERNAME_MAX_LENGTH}`;
+  if (!USERNAME_PATTERN.test(value)) return `must match ${USERNAME_PATTERN}`;
+  return '';
+}
+
+function deriveUsernameBase(name, oidcSubject) {
+  const normalized = normalizeUsernameCandidate(name);
+  if (normalized) return normalized;
+  return fallbackUsername(oidcSubject);
 }
 
 function resolveNicknameMap(organizationId) {
@@ -585,7 +632,18 @@ function handleUsersGateway(req, method, body, res) {
     }
     case 'CreateUser': {
       const id = randomUUID();
-      const username = deriveUsername(body, id);
+      const explicitUsername = body.username;
+      let username = '';
+      if (explicitUsername !== undefined && explicitUsername !== null) {
+        const value = String(explicitUsername);
+        const error = validateUsername(value);
+        if (error) {
+          return sendText(res, 400, `username: ${error}`);
+        }
+        username = value;
+      } else {
+        username = deriveUsernameBase(body.name ?? '', body.oidcSubject ?? id);
+      }
       const user = {
         id,
         oidcSubject: body.oidcSubject ?? `mock-${id}`,
@@ -611,7 +669,12 @@ function handleUsersGateway(req, method, body, res) {
       user.nickname = body.nickname ?? user.nickname;
       user.photoUrl = body.photoUrl ?? user.photoUrl;
       if (body.username !== undefined) {
-        user.username = body.username;
+        const value = String(body.username);
+        const error = validateUsername(value);
+        if (error) {
+          return sendText(res, 400, `username: ${error}`);
+        }
+        user.username = value;
       }
       if (body.clusterRole !== undefined) {
         user.clusterRole = normalizeClusterRole(body.clusterRole);
@@ -625,7 +688,14 @@ function handleUsersGateway(req, method, body, res) {
       if (body.name !== undefined) user.name = body.name;
       if (body.nickname !== undefined) user.nickname = body.nickname;
       if (body.photoUrl !== undefined) user.photoUrl = body.photoUrl;
-      if (body.username !== undefined) user.username = body.username;
+      if (body.username !== undefined) {
+        const value = String(body.username);
+        const error = validateUsername(value);
+        if (error) {
+          return sendText(res, 400, `username: ${error}`);
+        }
+        user.username = value;
+      }
       return sendJson(res, 200, { user: mapUser(user) });
     }
     case 'GetUser': {
@@ -642,7 +712,8 @@ function handleUsersGateway(req, method, body, res) {
     }
     case 'SearchUsers': {
       const prefix = String(body.prefix ?? '').toLowerCase();
-      const limit = Number.isFinite(body.limit) && body.limit > 0 ? body.limit : 25;
+      const requestedLimit = Number(body.limit);
+      const limit = Number.isFinite(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 20) : 10;
       const callerId = resolveRequestIdentity(req);
       const includePrivate = isClusterAdmin(callerId);
       const results = Array.from(users.values())

--- a/suites/playwright/test/e2e/mock-server.mjs
+++ b/suites/playwright/test/e2e/mock-server.mjs
@@ -20,6 +20,7 @@ const defaultEmail = 'e2e-tester@agyn.test';
 const users = new Map();
 const organizations = new Map();
 const memberships = new Map();
+const orgNicknames = new Map();
 const secretProviders = new Map();
 const secrets = new Map();
 const imagePullSecrets = new Map();
@@ -46,6 +47,7 @@ const defaultUser = {
   name: 'E2E Tester',
   email: defaultEmail,
   nickname: 'tester',
+  username: 'tester',
   photoUrl: '',
   clusterRole: 'CLUSTER_ROLE_ADMIN',
 };
@@ -220,6 +222,51 @@ function normalizeMessageOrder(value) {
   return 'MESSAGE_ORDER_UNSPECIFIED';
 }
 
+function resolveRequestIdentity(req) {
+  const header = req.headers['x-e2e-identity-id'];
+  if (Array.isArray(header)) {
+    return header[0] ? header[0].trim() : defaultUserId;
+  }
+  if (typeof header === 'string' && header.trim()) {
+    return header.trim();
+  }
+  return defaultUserId;
+}
+
+function isClusterAdmin(identityId) {
+  return users.get(identityId)?.clusterRole === 'CLUSTER_ROLE_ADMIN';
+}
+
+function deriveUsername(input, fallbackId) {
+  const candidate =
+    input.username ?? input.nickname ?? input.email?.split('@')[0] ?? input.name ?? `user-${fallbackId}`;
+  return String(candidate).trim() || `user-${fallbackId}`;
+}
+
+function resolveNicknameMap(organizationId) {
+  const existing = orgNicknames.get(organizationId);
+  if (existing) return existing;
+  const created = new Map();
+  orgNicknames.set(organizationId, created);
+  return created;
+}
+
+function seedDefaultNickname(organizationId, identityId) {
+  const user = users.get(identityId);
+  if (!user) return;
+  const username = (user.username ?? '').trim();
+  if (!username) return;
+  const nicknameMap = resolveNicknameMap(organizationId);
+  if (nicknameMap.has(username)) return;
+  nicknameMap.set(username, identityId);
+}
+
+function resolveOrgNickname(organizationId, nickname) {
+  const nicknameMap = orgNicknames.get(organizationId);
+  if (!nicknameMap) return null;
+  return nicknameMap.get(nickname) ?? null;
+}
+
 function normalizeGranularity(value) {
   if (typeof value === 'string') return value;
   if (value === 1) return 'GRANULARITY_TOTAL';
@@ -317,6 +364,7 @@ function mapUser(user) {
   return {
     meta: { id: user.id },
     oidcSubject: user.oidcSubject,
+    username: user.username,
     name: user.name,
     email: user.email,
     nickname: user.nickname,
@@ -513,10 +561,13 @@ function mapInstallationAuditLogEntry(entry) {
   };
 }
 
-function handleUsersGateway(method, body, res) {
+function handleUsersGateway(req, method, body, res) {
   switch (method) {
     case 'GetMe': {
-      return sendJson(res, 200, { user: mapUser(defaultUser), clusterRole: defaultUser.clusterRole });
+      const identityId = resolveRequestIdentity(req);
+      const user = users.get(identityId);
+      if (!user) return sendText(res, 404, 'User not found');
+      return sendJson(res, 200, { user: mapUser(user), clusterRole: user.clusterRole });
     }
     case 'ListUsers': {
       return sendJson(res, 200, {
@@ -534,12 +585,14 @@ function handleUsersGateway(method, body, res) {
     }
     case 'CreateUser': {
       const id = randomUUID();
+      const username = deriveUsername(body, id);
       const user = {
         id,
         oidcSubject: body.oidcSubject ?? `mock-${id}`,
         name: body.name ?? body.oidcSubject ?? id,
         email: body.email ?? '',
         nickname: body.nickname ?? '',
+        username,
         photoUrl: body.photoUrl ?? '',
         clusterRole: normalizeClusterRole(body.clusterRole),
       };
@@ -557,10 +610,23 @@ function handleUsersGateway(method, body, res) {
       user.name = body.name ?? user.name;
       user.nickname = body.nickname ?? user.nickname;
       user.photoUrl = body.photoUrl ?? user.photoUrl;
+      if (body.username !== undefined) {
+        user.username = body.username;
+      }
       if (body.clusterRole !== undefined) {
         user.clusterRole = normalizeClusterRole(body.clusterRole);
       }
       return sendJson(res, 200, { user: mapUser(user), clusterRole: user.clusterRole });
+    }
+    case 'UpdateMe': {
+      const identityId = resolveRequestIdentity(req);
+      const user = users.get(identityId);
+      if (!user) return sendText(res, 404, 'User not found');
+      if (body.name !== undefined) user.name = body.name;
+      if (body.nickname !== undefined) user.nickname = body.nickname;
+      if (body.photoUrl !== undefined) user.photoUrl = body.photoUrl;
+      if (body.username !== undefined) user.username = body.username;
+      return sendJson(res, 200, { user: mapUser(user) });
     }
     case 'GetUser': {
       const identityId = body.identityId;
@@ -573,6 +639,27 @@ function handleUsersGateway(method, body, res) {
     case 'DeleteUser': {
       if (body.identityId) users.delete(body.identityId);
       return sendJson(res, 200, {});
+    }
+    case 'SearchUsers': {
+      const prefix = String(body.prefix ?? '').toLowerCase();
+      const limit = Number.isFinite(body.limit) && body.limit > 0 ? body.limit : 25;
+      const callerId = resolveRequestIdentity(req);
+      const includePrivate = isClusterAdmin(callerId);
+      const results = Array.from(users.values())
+        .filter((user) => {
+          const username = (user.username ?? '').toLowerCase();
+          if (!username) return false;
+          if (!prefix) return true;
+          return username.startsWith(prefix);
+        })
+        .slice(0, limit)
+        .map((user) => ({
+          identityId: user.id,
+          username: user.username ?? '',
+          name: includePrivate ? user.name : '',
+          photoUrl: includePrivate ? user.photoUrl : '',
+        }));
+      return sendJson(res, 200, { users: results });
     }
     case 'CreateDevice': {
       const id = randomUUID();
@@ -602,21 +689,23 @@ function handleUsersGateway(method, body, res) {
   }
 }
 
-function handleOrganizationsGateway(method, body, res) {
+function handleOrganizationsGateway(req, method, body, res) {
   switch (method) {
     case 'CreateOrganization': {
       const id = randomUUID();
       const name = body.name ?? `org-${id}`;
       const org = { id, name };
       organizations.set(id, org);
+      const callerId = resolveRequestIdentity(req);
       const membership = {
         id: randomUUID(),
         organizationId: id,
-        identityId: defaultUserId,
+        identityId: callerId,
         role: 'MEMBERSHIP_ROLE_OWNER',
         status: 'MEMBERSHIP_STATUS_ACTIVE',
       };
       memberships.set(membership.id, membership);
+      seedDefaultNickname(id, callerId);
       return sendJson(res, 200, { organization: org });
     }
     case 'ListOrganizations': {
@@ -633,8 +722,9 @@ function handleOrganizationsGateway(method, body, res) {
     }
     case 'ListMyMemberships': {
       const status = normalizeMembershipStatus(body.status);
+      const callerId = resolveRequestIdentity(req);
       const result = Array.from(memberships.values()).filter((membership) => {
-        if (membership.identityId !== defaultUserId) return false;
+        if (membership.identityId !== callerId) return false;
         if (status === 'MEMBERSHIP_STATUS_UNSPECIFIED') return true;
         return membership.status === status;
       });
@@ -660,6 +750,17 @@ function handleOrganizationsGateway(method, body, res) {
       memberships.set(membership.id, membership);
       return sendJson(res, 200, { membership: mapMembership(membership) });
     }
+    case 'AcceptMembership': {
+      const membership = memberships.get(body.membershipId);
+      if (!membership) return sendText(res, 404, 'Membership not found');
+      const callerId = resolveRequestIdentity(req);
+      if (membership.identityId !== callerId) {
+        return sendText(res, 403, 'Membership does not belong to caller');
+      }
+      membership.status = 'MEMBERSHIP_STATUS_ACTIVE';
+      seedDefaultNickname(membership.organizationId, membership.identityId);
+      return sendJson(res, 200, { membership: mapMembership(membership) });
+    }
     case 'UpdateMembershipRole': {
       const membership = memberships.get(body.membershipId);
       if (!membership) return sendText(res, 404, 'Membership not found');
@@ -672,6 +773,20 @@ function handleOrganizationsGateway(method, body, res) {
     }
     default:
       return sendText(res, 404, 'Unknown OrganizationsGateway method');
+  }
+}
+
+function handleIdentityService(req, method, body, res) {
+  switch (method) {
+    case 'ResolveNickname': {
+      const organizationId = body.organizationId ?? '';
+      const nickname = body.nickname ?? '';
+      const identityId = resolveOrgNickname(organizationId, nickname);
+      if (!identityId) return sendText(res, 404, 'Nickname not found');
+      return sendJson(res, 200, { identityId, identityType: 'IDENTITY_TYPE_USER' });
+    }
+    default:
+      return sendText(res, 404, 'Unknown IdentityService method');
   }
 }
 
@@ -1359,10 +1474,10 @@ const server = http.createServer(async (req, res) => {
     const method = parts[2];
     if (!service || !method) return sendText(res, 404, 'Invalid gateway path');
     if (service === 'agynio.api.gateway.v1.UsersGateway') {
-      return handleUsersGateway(method, body, res);
+      return handleUsersGateway(req, method, body, res);
     }
     if (service === 'agynio.api.gateway.v1.OrganizationsGateway') {
-      return handleOrganizationsGateway(method, body, res);
+      return handleOrganizationsGateway(req, method, body, res);
     }
     if (service === 'agynio.api.gateway.v1.SecretsGateway') {
       return handleSecretsGateway(method, body, res);
@@ -1385,6 +1500,9 @@ const server = http.createServer(async (req, res) => {
     }
     if (service === 'agynio.api.gateway.v1.AppsGateway') {
       return handleAppsGateway(method, body, res);
+    }
+    if (service === 'agynio.api.identity.v1.IdentityService') {
+      return handleIdentityService(req, method, body, res);
     }
     return sendText(res, 404, 'Unknown gateway');
   }

--- a/suites/playwright/test/e2e/user-directory-api.spec.ts
+++ b/suites/playwright/test/e2e/user-directory-api.spec.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
+const ORGS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.OrganizationsGateway';
+const IDENTITY_SERVICE_PATH = '/api/agynio.api.identity.v1.IdentityService';
+
+const CONNECT_HEADERS = {
+  'Content-Type': 'application/json',
+  'Connect-Protocol-Version': '1',
+};
+
+type UserDirectoryEntry = {
+  identityId?: string;
+  username?: string;
+  name?: string;
+  photoUrl?: string;
+};
+
+async function postConnect<T>(
+  request: APIRequestContext,
+  path: string,
+  method: string,
+  data: Record<string, unknown>,
+  identityId?: string,
+): Promise<T> {
+  const headers = {
+    ...CONNECT_HEADERS,
+    ...(identityId ? { 'x-e2e-identity-id': identityId } : {}),
+  };
+  const response = await request.post(`${path}/${method}`, { data, headers });
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`${method} failed (${response.status()}): ${body}`);
+  }
+  return (await response.json()) as T;
+}
+
+async function createUser(
+  request: APIRequestContext,
+  opts: { email: string; username: string; name?: string; photoUrl?: string; nickname?: string },
+): Promise<string> {
+  const response = await postConnect<{ user?: { meta?: { id?: string } } }>(
+    request,
+    USERS_GATEWAY_PATH,
+    'CreateUser',
+    {
+      email: opts.email,
+      username: opts.username,
+      name: opts.name ?? opts.username,
+      nickname: opts.nickname ?? opts.username,
+      photoUrl: opts.photoUrl ?? '',
+    },
+  );
+  const identityId = response.user?.meta?.id;
+  if (!identityId) {
+    throw new Error('CreateUser response missing identity id.');
+  }
+  return identityId;
+}
+
+async function createOrganization(request: APIRequestContext, name: string): Promise<string> {
+  const response = await postConnect<{ organization?: { id?: string } }>(
+    request,
+    ORGS_GATEWAY_PATH,
+    'CreateOrganization',
+    { name },
+  );
+  const organizationId = response.organization?.id;
+  if (!organizationId) {
+    throw new Error('CreateOrganization response missing organization id.');
+  }
+  return organizationId;
+}
+
+async function searchUsers(
+  request: APIRequestContext,
+  opts: { prefix: string; identityId?: string },
+): Promise<UserDirectoryEntry[]> {
+  const response = await postConnect<{ users?: UserDirectoryEntry[] }>(
+    request,
+    USERS_GATEWAY_PATH,
+    'SearchUsers',
+    { prefix: opts.prefix, limit: 10 },
+    opts.identityId,
+  );
+  return response.users ?? [];
+}
+
+async function createMembership(
+  request: APIRequestContext,
+  opts: { organizationId: string; identityId: string },
+): Promise<string> {
+  const response = await postConnect<{ membership?: { id?: string } }>(
+    request,
+    ORGS_GATEWAY_PATH,
+    'CreateMembership',
+    {
+      organizationId: opts.organizationId,
+      identityId: opts.identityId,
+      role: 'MEMBERSHIP_ROLE_MEMBER',
+    },
+  );
+  const membershipId = response.membership?.id;
+  if (!membershipId) {
+    throw new Error('CreateMembership response missing membership id.');
+  }
+  return membershipId;
+}
+
+async function acceptMembership(
+  request: APIRequestContext,
+  opts: { membershipId: string; identityId: string },
+): Promise<void> {
+  await postConnect(
+    request,
+    ORGS_GATEWAY_PATH,
+    'AcceptMembership',
+    { membershipId: opts.membershipId },
+    opts.identityId,
+  );
+}
+
+async function updateUsername(
+  request: APIRequestContext,
+  opts: { identityId: string; username: string },
+): Promise<void> {
+  await postConnect(
+    request,
+    USERS_GATEWAY_PATH,
+    'UpdateMe',
+    { username: opts.username },
+    opts.identityId,
+  );
+}
+
+async function resolveOrgNickname(
+  request: APIRequestContext,
+  opts: { organizationId: string; nickname: string },
+): Promise<string> {
+  const response = await postConnect<{ identityId?: string }>(
+    request,
+    IDENTITY_SERVICE_PATH,
+    'ResolveNickname',
+    { organizationId: opts.organizationId, nickname: opts.nickname },
+  );
+  const identityId = response.identityId;
+  if (!identityId) {
+    throw new Error('ResolveNickname response missing identity id.');
+  }
+  return identityId;
+}
+
+test.describe('user-directory', { tag: ['@svc_console', '@issue140'] }, () => {
+  test('non-admin SearchUsers redacts profile fields', async ({ request }) => {
+    const suffix = randomUUID();
+    const targetUsername = `e2e-search-${suffix}`;
+    const callerUsername = `e2e-caller-${suffix}`;
+
+    const targetId = await createUser(request, {
+      email: `${targetUsername}@agyn.test`,
+      username: targetUsername,
+      name: 'Redacted User',
+      photoUrl: 'https://example.com/photo.png',
+    });
+    const callerId = await createUser(request, {
+      email: `${callerUsername}@agyn.test`,
+      username: callerUsername,
+    });
+
+    const results = await searchUsers(request, { prefix: targetUsername, identityId: callerId });
+    expect(results).toHaveLength(1);
+    const entry = results[0];
+    expect(entry.identityId).toBe(targetId);
+    expect(entry.username).toBe(targetUsername);
+    expect(entry.name ?? '').toBe('');
+    expect(entry.photoUrl ?? '').toBe('');
+  });
+
+  test('invite by username seeds org nickname on accept', async ({ request }) => {
+    const suffix = randomUUID();
+    const organizationId = await createOrganization(request, `e2e-org-${suffix}`);
+    const inviteeUsername = `e2e-invite-${suffix}`;
+
+    const inviteeId = await createUser(request, {
+      email: `${inviteeUsername}@agyn.test`,
+      username: inviteeUsername,
+      name: 'Invitee User',
+    });
+
+    const results = await searchUsers(request, { prefix: inviteeUsername });
+    expect(results).toHaveLength(1);
+    const inviteeEntry = results[0];
+    const entryIdentityId = inviteeEntry?.identityId;
+    if (!entryIdentityId) {
+      throw new Error('SearchUsers response missing identity id.');
+    }
+    const membershipId = await createMembership(request, {
+      organizationId,
+      identityId: entryIdentityId,
+    });
+
+    await acceptMembership(request, { membershipId, identityId: inviteeId });
+
+    const resolvedId = await resolveOrgNickname(request, {
+      organizationId,
+      nickname: inviteeUsername,
+    });
+    expect(resolvedId).toBe(inviteeId);
+  });
+
+  test('renaming username does not change existing org nickname', async ({ request }) => {
+    const suffix = randomUUID();
+    const organizationId = await createOrganization(request, `e2e-org-rename-${suffix}`);
+    const originalUsername = `e2e-user-${suffix}`;
+    const newUsername = `e2e-user-new-${suffix}`;
+
+    const inviteeId = await createUser(request, {
+      email: `${originalUsername}@agyn.test`,
+      username: originalUsername,
+      name: 'Rename User',
+    });
+
+    const membershipId = await createMembership(request, {
+      organizationId,
+      identityId: inviteeId,
+    });
+    await acceptMembership(request, { membershipId, identityId: inviteeId });
+
+    await updateUsername(request, { identityId: inviteeId, username: newUsername });
+
+    const resolvedId = await resolveOrgNickname(request, {
+      organizationId,
+      nickname: originalUsername,
+    });
+    expect(resolvedId).toBe(inviteeId);
+  });
+});

--- a/suites/playwright/test/e2e/user-directory-api.spec.ts
+++ b/suites/playwright/test/e2e/user-directory-api.spec.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import { expect, test, type APIRequestContext } from '@playwright/test';
 
 const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
@@ -9,6 +9,10 @@ const CONNECT_HEADERS = {
   'Content-Type': 'application/json',
   'Connect-Protocol-Version': '1',
 };
+
+function randomSuffix(): string {
+  return randomBytes(4).toString('hex');
+}
 
 type UserDirectoryEntry = {
   identityId?: string;
@@ -153,7 +157,7 @@ async function resolveOrgNickname(
 
 test.describe('user-directory', { tag: ['@svc_console', '@issue140'] }, () => {
   test('non-admin SearchUsers redacts profile fields', async ({ request }) => {
-    const suffix = randomUUID();
+    const suffix = randomSuffix();
     const targetUsername = `e2e-search-${suffix}`;
     const callerUsername = `e2e-caller-${suffix}`;
 
@@ -178,7 +182,7 @@ test.describe('user-directory', { tag: ['@svc_console', '@issue140'] }, () => {
   });
 
   test('invite by username seeds org nickname on accept', async ({ request }) => {
-    const suffix = randomUUID();
+    const suffix = randomSuffix();
     const organizationId = await createOrganization(request, `e2e-org-${suffix}`);
     const inviteeUsername = `e2e-invite-${suffix}`;
 
@@ -210,7 +214,7 @@ test.describe('user-directory', { tag: ['@svc_console', '@issue140'] }, () => {
   });
 
   test('renaming username does not change existing org nickname', async ({ request }) => {
-    const suffix = randomUUID();
+    const suffix = randomSuffix();
     const organizationId = await createOrganization(request, `e2e-org-rename-${suffix}`);
     const originalUsername = `e2e-user-${suffix}`;
     const newUsername = `e2e-user-new-${suffix}`;


### PR DESCRIPTION
## Summary
- add mock server support for usernames, SearchUsers redaction, membership acceptance, and org nickname resolution
- add API-focused Playwright tests for SearchUsers redaction and username-based invites/nickname behavior (@issue140)

## Testing
- npm ci --no-fund --no-audit
- npx buf generate
- CI=true npx playwright test --grep @issue140

Refs #140