### PR TITLE
Migrate media-proxy E2E tests

### DIFF
--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -4,7 +4,7 @@ manifests:
   - manifests/agents-orchestrator
 service_account: agents-orchestrator-e2e
 select: |
-  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "svc_organizations" "svc_files" "smoke")
+  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "svc_organizations" "svc_files" "svc_media_proxy" "smoke")
 
   if [ -z "${TAGS:-}" ]; then
     echo "smoke"

--- a/suites/go-core/tests/env_helpers_test.go
+++ b/suites/go-core/tests/env_helpers_test.go
@@ -1,0 +1,20 @@
+//go:build e2e
+
+package tests
+
+import (
+	"os"
+	"strings"
+)
+
+func envOrDefault(key, fallback string) string {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
+}

--- a/suites/go-core/tests/files_helpers_test.go
+++ b/suites/go-core/tests/files_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_files || smoke)
+//go:build e2e && (svc_files || svc_media_proxy || smoke)
 
 package tests
 

--- a/suites/go-core/tests/grpc.go
+++ b/suites/go-core/tests/grpc.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || svc_files || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || svc_files || svc_media_proxy || smoke)
 
 package tests
 

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -69,18 +69,6 @@ type pipelineRun struct {
 	messageText    string
 }
 
-func envOrDefault(key, fallback string) string {
-	value, ok := os.LookupEnv(key)
-	if !ok {
-		return fallback
-	}
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return fallback
-	}
-	return trimmed
-}
-
 // pollUntil retries check at interval until it returns nil or ctx expires.
 func pollUntil(ctx context.Context, interval time.Duration, check func(ctx context.Context) error) error {
 	lastErr := check(ctx)

--- a/suites/go-core/tests/media_proxy_external_test.go
+++ b/suites/go-core/tests/media_proxy_external_test.go
@@ -1,0 +1,170 @@
+//go:build e2e && svc_media_proxy
+
+package tests
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	externalImageURL = "https://www.w3.org/Graphics/PNG/nurbcup2si.png"
+	externalHTMLURL  = "https://www.w3.org/"
+)
+
+func TestExternalProxy_PublicImage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalImageURL, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 200, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	contentType := strings.TrimSpace(response.Header.Get("Content-Type"))
+	if contentType != "image/png" {
+		t.Fatalf("expected content-type image/png, got %q", contentType)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected non-empty response body")
+	}
+}
+
+func TestExternalProxy_PublicImageWithResize(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalImageURL, 200), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 200, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected non-empty response body")
+	}
+
+	image := decodeImage(t, body)
+	bounds := image.Bounds()
+	if bounds.Dx() > 200 || bounds.Dy() > 200 {
+		t.Fatalf("expected resized image within 200px, got %dx%d", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestExternalProxy_NonImageURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalHTMLURL, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnsupportedMediaType {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 415, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func TestExternalProxy_Unauthenticated(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalImageURL, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newClient().Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 401, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func TestExternalProxy_InvalidToken(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalImageURL, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient("invalid").Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 401, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func TestExternalProxy_MissingURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, mediaProxyURL+"/proxy", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 400, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}

--- a/suites/go-core/tests/media_proxy_file_test.go
+++ b/suites/go-core/tests/media_proxy_file_test.go
@@ -1,0 +1,185 @@
+//go:build e2e && svc_media_proxy
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var testPNG = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+	0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+	0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54,
+	0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05,
+	0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4,
+	0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+	0xae, 0x42, 0x60, 0x82,
+}
+
+func TestFileProxy_UploadAndProxy(t *testing.T) {
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	fileID := uploadTestFile(t, uploadCtx, "e2e-upload.png", "image/png", testPNG)
+	uploadCancel()
+
+	proxyCtx, proxyCancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer proxyCancel()
+
+	request, err := http.NewRequestWithContext(proxyCtx, http.MethodGet, proxyURL("agyn://file/"+fileID, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 200, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	contentType := strings.TrimSpace(response.Header.Get("Content-Type"))
+	if contentType != "image/png" {
+		t.Fatalf("expected content-type image/png, got %q", contentType)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if !bytes.Equal(body, testPNG) {
+		t.Fatal("proxied file did not match uploaded content")
+	}
+}
+
+func TestFileProxy_UploadAndProxyWithResize(t *testing.T) {
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	fileID := uploadTestFile(t, uploadCtx, "e2e-resize.png", "image/png", testPNG)
+	uploadCancel()
+
+	proxyCtx, proxyCancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer proxyCancel()
+
+	request, err := http.NewRequestWithContext(proxyCtx, http.MethodGet, proxyURL("agyn://file/"+fileID, 100), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 200, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected non-empty response body")
+	}
+
+	image := decodeImage(t, body)
+	bounds := image.Bounds()
+	if bounds.Dx() > 100 || bounds.Dy() > 100 {
+		t.Fatalf("expected resized image within 100px, got %dx%d", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestFileProxy_NotFoundFile(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL("agyn://file/"+uuid.NewString(), 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 404, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func TestFileProxy_RangeRequest(t *testing.T) {
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	fileID := uploadTestFile(t, uploadCtx, "e2e-range.png", "image/png", testPNG)
+	uploadCancel()
+
+	proxyCtx, proxyCancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer proxyCancel()
+
+	request, err := http.NewRequestWithContext(proxyCtx, http.MethodGet, proxyURL("agyn://file/"+fileID, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	request.Header.Set("Range", "bytes=0-10")
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusPartialContent {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 206, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	contentRange := strings.TrimSpace(response.Header.Get("Content-Range"))
+	if !strings.HasPrefix(contentRange, "bytes 0-10/") {
+		t.Fatalf("expected content-range header for bytes 0-10, got %q", contentRange)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(body) != 11 {
+		t.Fatalf("expected 11 bytes, got %d", len(body))
+	}
+}
+
+func TestFileProxy_Unauthenticated(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL("agyn://file/"+uuid.NewString(), 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newClient().Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 401, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}

--- a/suites/go-core/tests/media_proxy_helpers_test.go
+++ b/suites/go-core/tests/media_proxy_helpers_test.go
@@ -1,0 +1,331 @@
+//go:build e2e && svc_media_proxy
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	_ "image/png"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	filesv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/files/v1"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	mockAuthTokenURL = "https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc/token"
+	mockAuthClientID = "client_MU95KU3gHQf5Ir7p"
+
+	identityMetadataKey     = "x-identity-id"
+	identityTypeMetadataKey = "x-identity-type"
+)
+
+var (
+	mediaProxyURL = envOrDefault("MEDIA_PROXY_URL", "http://media-proxy:8080")
+	gatewayURL    = envOrDefault("GATEWAY_URL", "http://gateway-gateway:8080")
+
+	accessToken      string
+	resolvedIdentity mediaProxyIdentity
+)
+
+type identityType string
+
+const (
+	identityTypeUser   identityType = "user"
+	identityTypeAgent  identityType = "agent"
+	identityTypeApp    identityType = "app"
+	identityTypeRunner identityType = "runner"
+)
+
+type mediaProxyIdentity struct {
+	IdentityID   string
+	IdentityType identityType
+}
+
+type mePayload struct {
+	IdentityID   string `json:"identity_id"`
+	IdentityType string `json:"identity_type"`
+}
+
+func TestMain(m *testing.M) {
+	cleanup := &cleanupStack{}
+	ctx := context.Background()
+
+	if err := setupCredentials(ctx, cleanup); err != nil {
+		exitWithSetupError(cleanup, fmt.Errorf("setup credentials: %w", err))
+	}
+
+	exitCode := m.Run()
+	cleanup.Run()
+	os.Exit(exitCode)
+}
+
+type cleanupStack struct {
+	fns []func()
+}
+
+func (c *cleanupStack) Add(fn func()) {
+	c.fns = append(c.fns, fn)
+}
+
+func (c *cleanupStack) Run() {
+	for i := len(c.fns) - 1; i >= 0; i-- {
+		c.fns[i]()
+	}
+}
+
+func exitWithSetupError(cleanup *cleanupStack, err error) {
+	cleanup.Run()
+	fmt.Fprintf(os.Stderr, "e2e setup failed: %v\n", err)
+	os.Exit(1)
+}
+
+func setupCredentials(ctx context.Context, _ *cleanupStack) error {
+	requestCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	token, err := requestOIDCAccessToken(requestCtx)
+	if err != nil {
+		return err
+	}
+
+	meCtx, meCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer meCancel()
+
+	identityInfo, err := fetchIdentity(meCtx, token)
+	if err != nil {
+		return err
+	}
+
+	accessToken = token
+	resolvedIdentity = identityInfo
+	return nil
+}
+
+func requestOIDCAccessToken(ctx context.Context) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("username", "e2e-test-user@test.com")
+	form.Set("scope", "openid profile email")
+	form.Set("client_id", mockAuthClientID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, mockAuthTokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := newClient().Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("mockauth token request failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+
+	token := strings.TrimSpace(payload.AccessToken)
+	if token == "" {
+		return "", fmt.Errorf("mockauth access_token missing")
+	}
+
+	return token, nil
+}
+
+func fetchIdentity(ctx context.Context, token string) (mediaProxyIdentity, error) {
+	client := newAuthenticatedClient(token)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gatewayURL+"/me", nil)
+	if err != nil {
+		return mediaProxyIdentity{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return mediaProxyIdentity{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return mediaProxyIdentity{}, fmt.Errorf("me endpoint failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload mePayload
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return mediaProxyIdentity{}, err
+	}
+
+	identityID := strings.TrimSpace(payload.IdentityID)
+	if identityID == "" {
+		return mediaProxyIdentity{}, fmt.Errorf("identity_id missing")
+	}
+	identityType, err := parseIdentityType(payload.IdentityType)
+	if err != nil {
+		return mediaProxyIdentity{}, err
+	}
+
+	return mediaProxyIdentity{IdentityID: identityID, IdentityType: identityType}, nil
+}
+
+func parseIdentityType(value string) (identityType, error) {
+	trimmed := strings.TrimSpace(value)
+	switch trimmed {
+	case string(identityTypeUser):
+		return identityTypeUser, nil
+	case string(identityTypeAgent):
+		return identityTypeAgent, nil
+	case string(identityTypeApp):
+		return identityTypeApp, nil
+	case string(identityTypeRunner):
+		return identityTypeRunner, nil
+	default:
+		return "", fmt.Errorf("unsupported identity type: %q", value)
+	}
+}
+
+func proxyURL(rawURL string, size int) string {
+	params := url.Values{}
+	params.Set("url", strings.TrimSpace(rawURL))
+	if size > 0 {
+		params.Set("size", strconv.Itoa(size))
+	}
+
+	return mediaProxyURL + "/proxy?" + params.Encode()
+}
+
+func uploadTestFile(t *testing.T, ctx context.Context, filename, contentType string, data []byte) string {
+	t.Helper()
+
+	resolved := resolvedIdentity
+	if resolved.IdentityID == "" {
+		t.Fatal("identity id missing")
+	}
+	if resolved.IdentityType == "" {
+		t.Fatal("identity type missing")
+	}
+	if len(data) == 0 {
+		t.Fatal("file data is empty")
+	}
+
+	uploadCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		identityMetadataKey, resolved.IdentityID,
+		identityTypeMetadataKey, string(resolved.IdentityType),
+	))
+	client := newFilesClient(t)
+	stream, err := client.UploadFile(uploadCtx)
+	if err != nil {
+		t.Fatalf("start upload: %v", err)
+	}
+
+	metadata := &filesv1.UploadFileRequest{
+		Payload: &filesv1.UploadFileRequest_Metadata{
+			Metadata: &filesv1.UploadFileMetadata{
+				Filename:    filename,
+				ContentType: contentType,
+				SizeBytes:   int64(len(data)),
+			},
+		},
+	}
+	if err := stream.Send(metadata); err != nil {
+		t.Fatalf("send metadata: %v", err)
+	}
+
+	chunkSplit := len(data) / 2
+	if chunkSplit == 0 {
+		chunkSplit = len(data)
+	}
+	if err := stream.Send(&filesv1.UploadFileRequest{
+		Payload: &filesv1.UploadFileRequest_Chunk{
+			Chunk: &filesv1.UploadFileChunk{Data: data[:chunkSplit]},
+		},
+	}); err != nil {
+		t.Fatalf("send chunk: %v", err)
+	}
+	if chunkSplit < len(data) {
+		if err := stream.Send(&filesv1.UploadFileRequest{
+			Payload: &filesv1.UploadFileRequest_Chunk{
+				Chunk: &filesv1.UploadFileChunk{Data: data[chunkSplit:]},
+			},
+		}); err != nil {
+			t.Fatalf("send chunk: %v", err)
+		}
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		t.Fatalf("finish upload: %v", err)
+	}
+	if resp == nil || resp.GetFile() == nil {
+		t.Fatal("missing file in upload response")
+	}
+
+	fileID := strings.TrimSpace(resp.GetFile().GetId())
+	if fileID == "" {
+		t.Fatal("missing file id in upload response")
+	}
+
+	return fileID
+}
+
+func decodeImage(t *testing.T, data []byte) image.Image {
+	t.Helper()
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode image: %v", err)
+	}
+
+	return img
+}
+
+func newClient() *http.Client {
+	return &http.Client{Timeout: 15 * time.Second}
+}
+
+func newAuthenticatedClient(token string) *http.Client {
+	client := newClient()
+	client.Transport = bearerTransport{token: token, base: client.Transport}
+	return client
+}
+
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+t.token)
+	return base.RoundTrip(clone)
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/suites/go-core/tests/media_proxy_helpers_test.go
+++ b/suites/go-core/tests/media_proxy_helpers_test.go
@@ -26,8 +26,8 @@ const (
 	mockAuthTokenURL = "https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc/token"
 	mockAuthClientID = "client_MU95KU3gHQf5Ir7p"
 
-	identityMetadataKey     = "x-identity-id"
-	identityTypeMetadataKey = "x-identity-type"
+	mediaProxyIdentityMetadataKey     = "x-identity-id"
+	mediaProxyIdentityTypeMetadataKey = "x-identity-type"
 )
 
 var (
@@ -38,18 +38,18 @@ var (
 	resolvedIdentity mediaProxyIdentity
 )
 
-type identityType string
+type mediaProxyIdentityType string
 
 const (
-	identityTypeUser   identityType = "user"
-	identityTypeAgent  identityType = "agent"
-	identityTypeApp    identityType = "app"
-	identityTypeRunner identityType = "runner"
+	mediaProxyIdentityTypeUser   mediaProxyIdentityType = "user"
+	mediaProxyIdentityTypeAgent  mediaProxyIdentityType = "agent"
+	mediaProxyIdentityTypeApp    mediaProxyIdentityType = "app"
+	mediaProxyIdentityTypeRunner mediaProxyIdentityType = "runner"
 )
 
 type mediaProxyIdentity struct {
 	IdentityID   string
-	IdentityType identityType
+	IdentityType mediaProxyIdentityType
 }
 
 type mePayload struct {
@@ -186,17 +186,17 @@ func fetchIdentity(ctx context.Context, token string) (mediaProxyIdentity, error
 	return mediaProxyIdentity{IdentityID: identityID, IdentityType: identityType}, nil
 }
 
-func parseIdentityType(value string) (identityType, error) {
+func parseIdentityType(value string) (mediaProxyIdentityType, error) {
 	trimmed := strings.TrimSpace(value)
 	switch trimmed {
-	case string(identityTypeUser):
-		return identityTypeUser, nil
-	case string(identityTypeAgent):
-		return identityTypeAgent, nil
-	case string(identityTypeApp):
-		return identityTypeApp, nil
-	case string(identityTypeRunner):
-		return identityTypeRunner, nil
+	case string(mediaProxyIdentityTypeUser):
+		return mediaProxyIdentityTypeUser, nil
+	case string(mediaProxyIdentityTypeAgent):
+		return mediaProxyIdentityTypeAgent, nil
+	case string(mediaProxyIdentityTypeApp):
+		return mediaProxyIdentityTypeApp, nil
+	case string(mediaProxyIdentityTypeRunner):
+		return mediaProxyIdentityTypeRunner, nil
 	default:
 		return "", fmt.Errorf("unsupported identity type: %q", value)
 	}
@@ -227,8 +227,8 @@ func uploadTestFile(t *testing.T, ctx context.Context, filename, contentType str
 	}
 
 	uploadCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs(
-		identityMetadataKey, resolved.IdentityID,
-		identityTypeMetadataKey, string(resolved.IdentityType),
+		mediaProxyIdentityMetadataKey, resolved.IdentityID,
+		mediaProxyIdentityTypeMetadataKey, string(resolved.IdentityType),
 	))
 	client := newFilesClient(t)
 	stream, err := client.UploadFile(uploadCtx)
@@ -321,11 +321,4 @@ func (t bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	clone := req.Clone(req.Context())
 	clone.Header.Set("Authorization", "Bearer "+t.token)
 	return base.RoundTrip(clone)
-}
-
-func envOrDefault(key, fallback string) string {
-	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
-		return value
-	}
-	return fallback
 }


### PR DESCRIPTION
## Summary
- port media-proxy E2E coverage into suites/go-core/tests under svc_media_proxy
- add svc_media_proxy to suite selection and helper build tags
- include media-proxy auth/setup helpers and external proxy coverage

## Testing
- go test -c -tags "e2e svc_media_proxy" ./tests
- go vet -tags "e2e svc_media_proxy" ./tests/...

Closes #28