### PR TITLE
fix(go-core): use admin identity in org list

### DIFF
--- a/suites/go-core/tests/identity_constants_test.go
+++ b/suites/go-core/tests/identity_constants_test.go
@@ -1,0 +1,5 @@
+//go:build e2e
+
+package tests
+
+const clusterAdminIdentityID = "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"

--- a/suites/go-core/tests/organizations_test.go
+++ b/suites/go-core/tests/organizations_test.go
@@ -27,6 +27,7 @@ func TestOrganizationsServiceE2E(t *testing.T) {
 	testID := uuid.NewString()
 	identityID := uuid.NewString()
 	identityCtx := identityContext(ctx, identityID)
+	adminCtx := identityContext(ctx, clusterAdminIdentityID)
 
 	organizationResp1, err := client.CreateOrganization(identityCtx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Alpha " + testID})
 	require.NoError(t, err)
@@ -56,12 +57,12 @@ func TestOrganizationsServiceE2E(t *testing.T) {
 	require.NotNil(t, updatedOrg)
 	require.Equal(t, "Organization Alpha Updated "+testID, updatedOrg.GetName())
 
-	listResp, err := client.ListOrganizations(ctx, &organizationsv1.ListOrganizationsRequest{PageSize: 1})
+	listResp, err := client.ListOrganizations(adminCtx, &organizationsv1.ListOrganizationsRequest{PageSize: 1})
 	require.NoError(t, err)
 	require.NotEmpty(t, listResp.GetOrganizations())
 	require.NotEmpty(t, listResp.GetNextPageToken())
 
-	organizations := listOrganizations(ctx, t, client)
+	organizations := listOrganizations(adminCtx, t, client)
 	require.True(t, hasID(organizations, organizationID1))
 	require.True(t, hasID(organizations, organizationID2))
 

--- a/suites/go-core/tests/runners_helpers_test.go
+++ b/suites/go-core/tests/runners_helpers_test.go
@@ -21,8 +21,6 @@ const (
 	identityTypeUser        = "user"
 	identityTypeAgent       = "agent"
 
-	clusterAdminIdentityID = "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"
-
 	runnerContainerImage = "alpine:3.21"
 )
 


### PR DESCRIPTION
## Summary
- Pass cluster-admin identity metadata for ListOrganizations calls in go-core org e2e tests.
- Share the cluster-admin identity constant across e2e tags and keep pagination helper using admin context.

## Testing
- GOTOOLCHAIN=local go test ./...
- GOTOOLCHAIN=local go vet ./...

Refs #30