### PR TITLE
fix(gateway): stabilize gateway e2e tests

### DIFF
--- a/suites/go-core/tests/gateway_agents_test.go
+++ b/suites/go-core/tests/gateway_agents_test.go
@@ -20,6 +20,7 @@ func TestAgentsGateway_ListAgents(t *testing.T) {
 	defer cancel()
 
 	client := newAgentsGatewayClient(t)
+	agentID := createGatewayAgent(t, client)
 	resp, err := client.ListAgents(ctx, connect.NewRequest(&agentsv1.ListAgentsRequest{
 		OrganizationId: gatewayOrganizationID(t),
 	}))
@@ -27,6 +28,7 @@ func TestAgentsGateway_ListAgents(t *testing.T) {
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Msg)
 	require.NotNil(t, resp.Msg.Agents)
+	require.True(t, hasGatewayAgentID(resp.Msg.Agents, agentID))
 }
 
 func TestAgentsGateway_CreateAndDeleteAgent(t *testing.T) {
@@ -39,6 +41,8 @@ func TestAgentsGateway_CreateAndDeleteAgent(t *testing.T) {
 		Role:           "assistant",
 		Model:          gatewayModelID(t),
 		Configuration:  "{}",
+		Image:          gatewayAgentImage(t),
+		InitImage:      gatewayAgentInitImage(t),
 		OrganizationId: gatewayOrganizationID(t),
 	}
 	createResp, err := client.CreateAgent(ctx, connect.NewRequest(createReq))
@@ -66,11 +70,11 @@ func TestAgentsGateway_ListMcps(t *testing.T) {
 	defer cancel()
 
 	client := newAgentsGatewayClient(t)
-	resp, err := client.ListMcps(ctx, connect.NewRequest(&agentsv1.ListMcpsRequest{}))
+	agentID := createGatewayAgent(t, client)
+	resp, err := client.ListMcps(ctx, connect.NewRequest(&agentsv1.ListMcpsRequest{AgentId: agentID}))
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Msg)
-	require.NotNil(t, resp.Msg.Mcps)
 }
 
 func TestAgentsGateway_InvalidPayloadReturnsClientError(t *testing.T) {
@@ -88,4 +92,46 @@ func newAgentsGatewayClient(t *testing.T) gatewayv1connect.AgentsGatewayClient {
 		newGatewayAuthenticatedClient(t, gatewayAPIToken(t)),
 		gatewayBaseURL(t),
 	)
+}
+
+func createGatewayAgent(t *testing.T, client gatewayv1connect.AgentsGatewayClient) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), gatewayRequestTimeout)
+	defer cancel()
+
+	resp, err := client.CreateAgent(ctx, connect.NewRequest(&agentsv1.CreateAgentRequest{
+		Name:           fmt.Sprintf("e2e-gateway-agent-%s", uuid.NewString()),
+		Role:           "assistant",
+		Model:          gatewayModelID(t),
+		Configuration:  "{}",
+		Image:          gatewayAgentImage(t),
+		InitImage:      gatewayAgentInitImage(t),
+		OrganizationId: gatewayOrganizationID(t),
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Msg)
+	require.NotNil(t, resp.Msg.Agent)
+	require.NotNil(t, resp.Msg.Agent.Meta)
+
+	agentID := strings.TrimSpace(resp.Msg.Agent.Meta.Id)
+	require.NotEmpty(t, agentID)
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), gatewayRequestTimeout)
+		defer cleanupCancel()
+		_, _ = client.DeleteAgent(cleanupCtx, connect.NewRequest(&agentsv1.DeleteAgentRequest{Id: agentID}))
+	})
+
+	return agentID
+}
+
+func hasGatewayAgentID(agents []*agentsv1.Agent, agentID string) bool {
+	for _, agent := range agents {
+		if strings.TrimSpace(agent.GetMeta().GetId()) == agentID {
+			return true
+		}
+	}
+	return false
 }

--- a/suites/go-core/tests/gateway_helpers_test.go
+++ b/suites/go-core/tests/gateway_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -14,18 +15,25 @@ import (
 	"testing"
 	"time"
 
+	usersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/users/v1"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
-	gatewayBaseURLEnvKey      = "AGYN_BASE_URL"
-	gatewayAPITokenEnvKey     = "AGYN_API_TOKEN"
-	gatewayOrganizationEnvKey = "AGYN_ORGANIZATION_ID"
-	gatewayModelEnvKey        = "AGYN_MODEL_ID"
-	zitiManagementAddrEnvKey  = "ZITI_MANAGEMENT_ADDRESS"
-	defaultZitiManagementAddr = "ziti-management:50051"
-	zitiGatewayBaseURL        = "http://gateway"
-	gatewayRequestTimeout     = 30 * time.Second
+	gatewayBaseURLEnvKey        = "AGYN_BASE_URL"
+	gatewayAPITokenEnvKey       = "AGYN_API_TOKEN"
+	gatewayOrganizationEnvKey   = "AGYN_ORGANIZATION_ID"
+	gatewayModelEnvKey          = "AGYN_MODEL_ID"
+	gatewayAgentImageEnvKey     = "AGYN_AGENT_IMAGE"
+	gatewayAgentInitImageEnvKey = "AGYN_AGENT_INIT_IMAGE"
+	gatewayUsersAddrEnvKey      = "USERS_ADDRESS"
+	defaultGatewayUsersAddr     = "users:50051"
+	zitiManagementAddrEnvKey    = "ZITI_MANAGEMENT_ADDRESS"
+	defaultZitiManagementAddr   = "ziti-management:50051"
+	zitiGatewayBaseURL          = "http://gateway"
+	gatewayRequestTimeout       = 30 * time.Second
 )
 
 type gatewayMePayload struct {
@@ -77,6 +85,20 @@ func gatewayModelID(t *testing.T) string {
 	return requireGatewayEnv(t, gatewayModelEnvKey)
 }
 
+func gatewayAgentImage(t *testing.T) string {
+	t.Helper()
+	return requireGatewayEnv(t, gatewayAgentImageEnvKey)
+}
+
+func gatewayAgentInitImage(t *testing.T) string {
+	t.Helper()
+	return requireGatewayEnv(t, gatewayAgentInitImageEnvKey)
+}
+
+func gatewayUsersAddr() string {
+	return envOrDefault(gatewayUsersAddrEnvKey, defaultGatewayUsersAddr)
+}
+
 func zitiManagementAddr(t *testing.T) string {
 	t.Helper()
 	return envOrDefault(zitiManagementAddrEnvKey, defaultZitiManagementAddr)
@@ -104,6 +126,48 @@ func newGatewayAuthenticatedClient(t *testing.T, token string) *http.Client {
 	client := newGatewayClient(t)
 	client.Transport = gatewayBearerTransport{token: token, base: client.Transport}
 	return client
+}
+
+func gatewayUserToken(t *testing.T) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), gatewayRequestTimeout)
+	defer cancel()
+
+	usersConn := dialGRPC(t, gatewayUsersAddr())
+	usersClient := usersv1.NewUsersServiceClient(usersConn)
+
+	subject := fmt.Sprintf("e2e-gateway-%s", uuid.NewString())
+	name := fmt.Sprintf("E2E Gateway %s", subject)
+	email := fmt.Sprintf("%s@test.local", subject)
+
+	resp, err := usersClient.ResolveOrCreateUser(ctx, &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: subject,
+		Name:        name,
+		Email:       email,
+	})
+	require.NoError(t, err)
+	if resp == nil || resp.GetUser() == nil || resp.GetUser().GetMeta() == nil {
+		t.Fatal("resolve user: missing user metadata")
+	}
+	identityID := strings.TrimSpace(resp.GetUser().GetMeta().GetId())
+	if identityID == "" {
+		t.Fatal("resolve user: identity id missing")
+	}
+
+	callCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("x-identity-id", identityID))
+	tokenResp, err := usersClient.CreateAPIToken(callCtx, &usersv1.CreateAPITokenRequest{
+		Name: fmt.Sprintf("e2e-gateway-token-%s", uuid.NewString()),
+	})
+	require.NoError(t, err)
+	if tokenResp == nil || tokenResp.GetToken() == nil {
+		t.Fatal("create api token: missing response")
+	}
+	plaintext := strings.TrimSpace(tokenResp.GetPlaintextToken())
+	if plaintext == "" {
+		t.Fatal("create api token: plaintext token missing")
+	}
+	return plaintext
 }
 
 func gatewayTransport(t *testing.T) http.RoundTripper {

--- a/suites/go-core/tests/gateway_users_test.go
+++ b/suites/go-core/tests/gateway_users_test.go
@@ -47,6 +47,7 @@ func TestAPIToken_ConnectRPCEndpointAuthenticated(t *testing.T) {
 	defer cancel()
 
 	client := newAgentsGatewayClient(t)
+	agentID := createGatewayAgent(t, client)
 	resp, err := client.ListAgents(ctx, connect.NewRequest(&agentsv1.ListAgentsRequest{
 		OrganizationId: gatewayOrganizationID(t),
 	}))
@@ -54,6 +55,7 @@ func TestAPIToken_ConnectRPCEndpointAuthenticated(t *testing.T) {
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Msg)
 	require.NotNil(t, resp.Msg.Agents)
+	require.True(t, hasGatewayAgentID(resp.Msg.Agents, agentID))
 }
 
 func TestAPIToken_ConnectRPCEndpointInvalidToken(t *testing.T) {
@@ -142,12 +144,13 @@ func TestUsersGateway_CreateAPITokenUnauthenticated(t *testing.T) {
 }
 
 func TestAPIToken_CreatedTokenAuthenticates(t *testing.T) {
-	baseIdentity := fetchGatewayIdentity(t, gatewayAPIToken(t))
+	baseToken := gatewayUserToken(t)
+	baseIdentity := fetchGatewayIdentity(t, baseToken)
 
 	ctx, cancel := context.WithTimeout(context.Background(), gatewayRequestTimeout)
 	defer cancel()
 
-	client := newUsersGatewayClient(t)
+	client := newUsersGatewayClientWithToken(t, baseToken)
 	createResp, err := client.CreateAPIToken(ctx, connect.NewRequest(&usersv1.CreateAPITokenRequest{
 		Name: fmt.Sprintf("e2e-roundtrip-token-%d", time.Now().UnixNano()),
 	}))
@@ -174,8 +177,13 @@ func TestAPIToken_CreatedTokenAuthenticates(t *testing.T) {
 
 func newUsersGatewayClient(t *testing.T) gatewayv1connect.UsersGatewayClient {
 	t.Helper()
+	return newUsersGatewayClientWithToken(t, gatewayUserToken(t))
+}
+
+func newUsersGatewayClientWithToken(t *testing.T, token string) gatewayv1connect.UsersGatewayClient {
+	t.Helper()
 	return gatewayv1connect.NewUsersGatewayClient(
-		newGatewayAuthenticatedClient(t, gatewayAPIToken(t)),
+		newGatewayAuthenticatedClient(t, token),
 		gatewayBaseURL(t),
 	)
 }


### PR DESCRIPTION
## Summary
- add gateway helpers for user API token setup in tests
- populate agent image/init image and precreate agents for list coverage
- switch gateway token tests to use user tokens where required

## Testing
- go test ./... (suites/go-core)
- go test ./... (suites/go-terraform)
- go vet ./... (suites/go-core)
- go vet ./... (suites/go-terraform)

Closes #42
Refs agynio/gateway#167