### PR TITLE
fix(playwright): allow run url params

### DIFF
--- a/suites/playwright-tracing-app/test/e2e/message-deeplink-fullchain.spec.ts
+++ b/suites/playwright-tracing-app/test/e2e/message-deeplink-fullchain.spec.ts
@@ -8,7 +8,7 @@ test.describe('message deep link full chain', { tag: ['@svc_tracing_app', '@svc_
 
     await page.goto(`/message/${run.messageId}?orgId=${run.organizationId}`);
 
-    const runUrlPattern = new RegExp(`/${run.organizationId}/runs/[0-9a-f]{32}$`);
+    const runUrlPattern = new RegExp(`/${run.organizationId}/runs/[0-9a-f]{32}(\\?.*)?$`);
     await expect(page).toHaveURL(runUrlPattern, { timeout: 60000 });
 
     const currentUrl = new URL(page.url());


### PR DESCRIPTION
## Summary
- allow message deeplink run URL regex to accept optional query parameters

## Testing
- npx eslint . --config eslint.config.js (suites/playwright-tracing-app)
- PYTHONPATH=/nix/store/jl0mxihyizv77l66mzbvmv49iiri72sd-python3.13-pyyaml-6.0.3/lib/python3.13/site-packages AGYN_API_TOKEN=*** AGYN_ORGANIZATION_ID=*** AGYN_MODEL_ID=*** AGYN_AGENT_IMAGE=ghcr.io/agynio/agent-runtime:v1.0.0 AGYN_AGENT_INIT_IMAGE=ghcr.io/agynio/agent-init:v1.0.0 DEVSPACE_NAMESPACE=platform devspace run test-e2e

## Issue
- #43