### PR TITLE
Add provider-only terraform tag toggle

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -7,6 +7,10 @@ inputs:
   tag:
     description: Additional tags (comma-separated or repeated by callers).
     required: false
+  include_smoke:
+    description: When tags are provided, append the smoke tag.
+    required: false
+    default: "true"
   provider-binary:
     description: Optional path to a Terraform provider binary in the caller workspace.
     required: false
@@ -337,6 +341,12 @@ runs:
           fi
         done
 
+        include_smoke="${{ inputs.include_smoke }}"
+        if [ -z "$include_smoke" ]; then
+          include_smoke="true"
+        fi
+        include_smoke=$(echo "$include_smoke" | tr '[:upper:]' '[:lower:]')
+
         namespace="${DEVSPACE_NAMESPACE:-platform}"
         cd "$GITHUB_WORKSPACE/e2e"
 
@@ -351,7 +361,9 @@ runs:
           devspace run test-e2e
           exit_code=$?
         else
-          unique_tags+=("smoke")
+          if [ "$include_smoke" = "true" ]; then
+            unique_tags+=("smoke")
+          fi
           declare -A seen_run=()
           tag_args=()
           for tag in "${unique_tags[@]}"; do

--- a/suites/go-terraform/suite.yaml
+++ b/suites/go-terraform/suite.yaml
@@ -1,7 +1,7 @@
 image: ghcr.io/agynio/devcontainer-go:1
 workdir: /opt/app/data
 select: |
-  suite_tags=("svc_gateway")
+  suite_tags=("svc_gateway" "tf_provider_agyn")
 
   if [ -z "${TAGS:-}" ]; then
     echo "${suite_tags[0]}"
@@ -20,7 +20,7 @@ run: |
   set -euo pipefail
   cd /opt/app/data
 
-  suite_tags=("svc_gateway")
+  suite_tags=("svc_gateway" "tf_provider_agyn")
   tags=()
   if [ -n "${TAGS:-}" ]; then
     for tag in ${TAGS}; do

--- a/suites/go-terraform/tests/acc_env_test.go
+++ b/suites/go-terraform/tests/acc_env_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/acc_helpers_test.go
+++ b/suites/go-terraform/tests/acc_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_agent_test.go
+++ b/suites/go-terraform/tests/resource_agent_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_app_installation_test.go
+++ b/suites/go-terraform/tests/resource_app_installation_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_app_test.go
+++ b/suites/go-terraform/tests/resource_app_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_env_test.go
+++ b/suites/go-terraform/tests/resource_env_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_hook_test.go
+++ b/suites/go-terraform/tests/resource_hook_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_image_pull_secret_attachment_test.go
+++ b/suites/go-terraform/tests/resource_image_pull_secret_attachment_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_image_pull_secret_test.go
+++ b/suites/go-terraform/tests/resource_image_pull_secret_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_init_script_test.go
+++ b/suites/go-terraform/tests/resource_init_script_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_mcp_test.go
+++ b/suites/go-terraform/tests/resource_mcp_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_organization_test.go
+++ b/suites/go-terraform/tests/resource_organization_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_runner_test.go
+++ b/suites/go-terraform/tests/resource_runner_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_skill_test.go
+++ b/suites/go-terraform/tests/resource_skill_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_user_test.go
+++ b/suites/go-terraform/tests/resource_user_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_volume_attachment_test.go
+++ b/suites/go-terraform/tests/resource_volume_attachment_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 

--- a/suites/go-terraform/tests/resource_volume_test.go
+++ b/suites/go-terraform/tests/resource_volume_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_gateway
+//go:build e2e && (svc_gateway || tf_provider_agyn)
 
 package tests
 


### PR DESCRIPTION
## Summary
- add include_smoke toggle in run-tests composite action to control smoke tag append
- allow go-terraform suite selection by svc_gateway or tf_provider_agyn
- update go-terraform build tags for provider-only runs

## Testing
- go test ./... -tags \"e2e svc_gateway\" -run TestNonexistent (suites/go-terraform)
- go test ./... -tags \"e2e tf_provider_agyn\" -run TestNonexistent (suites/go-terraform)

Refs #47