### PR TITLE
test(e2e): cover oidc deep link

### DIFF
--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -57,7 +57,7 @@ var (
 	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.18")
+	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.19")
 	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.15")
 )
 

--- a/suites/playwright-tracing-app/test/e2e/message-deeplink-oidc.spec.ts
+++ b/suites/playwright-tracing-app/test/e2e/message-deeplink-oidc.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { readOidcSession } from './oidc-helpers';
+import { clearAuthState, completeMockAuthLogin, ensureMockAuthEmailStrategy } from './sign-in-helper';
+import { createFullChainRun } from './tracing-run';
+
+test.describe('message deep link oidc callback', { tag: ['@svc_tracing_app', '@svc_agents_orchestrator'] }, () => {
+  test.beforeAll(async ({ playwright }) => {
+    const request = await playwright.request.newContext();
+    try {
+      await ensureMockAuthEmailStrategy(request);
+    } finally {
+      await request.dispose();
+    }
+  });
+
+  test('returns to deep link after login', async ({ page }) => {
+    test.setTimeout(8 * 60_000);
+
+    await page.goto('/');
+    const initialCallback = page.waitForURL(/\/callback/, { timeout: 60000 });
+    await completeMockAuthLogin(page);
+    await initialCallback;
+
+    await expect
+      .poll(async () => {
+        const session = await readOidcSession(page);
+        return session?.accessToken ?? '';
+      }, { timeout: 60000 })
+      .not.toBe('');
+
+    const run = await createFullChainRun(page);
+
+    await clearAuthState(page);
+
+    const messageUrl = `/message/${run.messageId}?orgId=${run.organizationId}`;
+    await page.goto(messageUrl);
+
+    const callbackPromise = page.waitForURL(/\/callback/, { timeout: 60000 });
+    await completeMockAuthLogin(page);
+    await callbackPromise;
+
+    const messageUrlPattern = new RegExp(`/message/${run.messageId}\\?orgId=${run.organizationId}$`);
+    const runUrlPattern = new RegExp(`/${run.organizationId}/runs/${run.runId}(\\?.*)?$`);
+    const finalUrlPattern = new RegExp(`${messageUrlPattern.source}|${runUrlPattern.source}`);
+    await expect(page).toHaveURL(finalUrlPattern, { timeout: 60000 });
+
+    const currentUrl = page.url();
+    if (runUrlPattern.test(currentUrl)) {
+      const runIdFromUrl = new URL(currentUrl).pathname.split('/').pop();
+      if (!runIdFromUrl) {
+        throw new Error(`Run redirect URL did not include a run id: ${currentUrl}`);
+      }
+      expect(runIdFromUrl).toBe(run.runId);
+    } else {
+      await expect(page).toHaveURL(messageUrlPattern);
+    }
+  });
+});

--- a/suites/playwright-tracing-app/test/e2e/sign-in-helper.ts
+++ b/suites/playwright-tracing-app/test/e2e/sign-in-helper.ts
@@ -1,4 +1,4 @@
-import type { APIRequestContext, Page } from '@playwright/test';
+import type { APIRequestContext, Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { User, type IdTokenClaims } from 'oidc-client-ts';
 import { createHash, randomBytes } from 'node:crypto';
@@ -117,9 +117,9 @@ async function fillMockAuthLoginForm(
   }
 
   const strategyTabs = page.getByTestId('login-strategy-tabs');
-  if (await strategyTabs.isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (await isLocatorVisible(strategyTabs, 2000)) {
     const emailTab = strategyTabs.getByRole('tab', { name: 'Email' });
-    if (await emailTab.isVisible({ timeout: 2000 }).catch(() => false)) {
+    if (await isLocatorVisible(emailTab, 2000)) {
       await emailTab.click();
     }
   }
@@ -140,6 +140,33 @@ function readEnvValue(body: string, key: string): string | undefined {
   const matcher = new RegExp(`${key}:\\s*"([^"]*)"`);
   const match = body.match(matcher);
   return match ? match[1] : undefined;
+}
+
+function isTimeoutError(error: unknown): error is Error {
+  return error instanceof Error && error.name === 'TimeoutError';
+}
+
+async function isLocatorVisible(locator: Locator, timeout: number): Promise<boolean> {
+  try {
+    return await locator.isVisible({ timeout });
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function waitForLocator(locator: Locator, timeout: number): Promise<boolean> {
+  try {
+    await locator.waitFor({ timeout });
+    return true;
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      return false;
+    }
+    throw error;
+  }
 }
 
 async function resolveRuntimeEnv(request: APIRequestContext): Promise<Record<string, string | undefined>> {
@@ -304,7 +331,7 @@ export async function seedOidcSessionViaMockAuth(page: Page, options: SeedOidcOp
 
   const loginHeading = page.getByRole('heading', { level: 1, name: /Log in to/ });
   const loginReady = await Promise.race([
-    loginHeading.waitFor({ timeout: 10000 }).then(() => true).catch(() => false),
+    waitForLocator(loginHeading, 10000),
     redirectResponsePromise.then(() => false),
   ]);
 

--- a/suites/playwright-tracing-app/test/e2e/sign-in-helper.ts
+++ b/suites/playwright-tracing-app/test/e2e/sign-in-helper.ts
@@ -13,6 +13,11 @@ type SeedOidcOptions = {
   landingPath?: string;
 };
 
+type BrowserLoginOptions = {
+  onLoginPage?: (page: Page) => Promise<void>;
+  email?: string;
+};
+
 type OidcRuntimeConfig = {
   authority: string;
   clientId: string;
@@ -82,12 +87,53 @@ function decodeJwtPayload(token: string): IdTokenClaims {
   return claims as IdTokenClaims;
 }
 
-async function clearAuthState(page: Page): Promise<void> {
+export async function clearAuthState(page: Page): Promise<void> {
   await page.context().clearCookies();
-  await page.addInitScript(() => {
+  const expectedOrigin = new URL(resolveBaseUrl()).origin;
+  const clearedKey = 'e2e:oidc-cleared';
+  const clearStorage = ({ origin, key }: { origin: string; key: string }) => {
+    if (window.location.origin !== origin) return;
+    if (window.sessionStorage.getItem(key)) return;
     window.sessionStorage.clear();
     window.localStorage.clear();
-  });
+    window.sessionStorage.setItem(key, 'true');
+  };
+
+  await page.addInitScript(clearStorage, { origin: expectedOrigin, key: clearedKey });
+
+  const currentOrigin = new URL(page.url()).origin;
+  if (currentOrigin === expectedOrigin) {
+    await page.evaluate(clearStorage, { origin: expectedOrigin, key: clearedKey });
+  }
+}
+
+async function fillMockAuthLoginForm(
+  page: Page,
+  expectedEmail: string,
+  onLoginPage?: (page: Page) => Promise<void>,
+): Promise<void> {
+  if (onLoginPage) {
+    await onLoginPage(page);
+  }
+
+  const strategyTabs = page.getByTestId('login-strategy-tabs');
+  if (await strategyTabs.isVisible({ timeout: 2000 }).catch(() => false)) {
+    const emailTab = strategyTabs.getByRole('tab', { name: 'Email' });
+    if (await emailTab.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await emailTab.click();
+    }
+  }
+
+  const emailInput = page.getByTestId('login-email-input');
+  if ((await emailInput.count()) > 0) {
+    await expect(emailInput).toBeVisible({ timeout: 5000 });
+    await emailInput.fill(expectedEmail);
+  } else {
+    const usernameInput = page.getByTestId('login-username-input');
+    await expect(usernameInput).toBeVisible({ timeout: 5000 });
+    await usernameInput.fill(expectedEmail);
+  }
+  await page.getByRole('button', { name: 'Continue' }).click();
 }
 
 function readEnvValue(body: string, key: string): string | undefined {
@@ -263,28 +309,7 @@ export async function seedOidcSessionViaMockAuth(page: Page, options: SeedOidcOp
   ]);
 
   if (loginReady) {
-    if (options.onLoginPage) {
-      await options.onLoginPage(page);
-    }
-
-    const strategyTabs = page.getByTestId('login-strategy-tabs');
-    if (await strategyTabs.isVisible({ timeout: 2000 }).catch(() => false)) {
-      const emailTab = strategyTabs.getByRole('tab', { name: 'Email' });
-      if (await emailTab.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await emailTab.click();
-      }
-    }
-
-    const emailInput = page.getByTestId('login-email-input');
-    if ((await emailInput.count()) > 0) {
-      await expect(emailInput).toBeVisible({ timeout: 5000 });
-      await emailInput.fill(expectedEmail);
-    } else {
-      const usernameInput = page.getByTestId('login-username-input');
-      await expect(usernameInput).toBeVisible({ timeout: 5000 });
-      await usernameInput.fill(expectedEmail);
-    }
-    await page.getByRole('button', { name: 'Continue' }).click();
+    await fillMockAuthLoginForm(page, expectedEmail, options.onLoginPage);
   }
 
   const redirectResponse = await redirectResponsePromise;
@@ -304,4 +329,11 @@ export async function seedOidcSessionViaMockAuth(page: Page, options: SeedOidcOp
 
   const tokens = await exchangeAuthCode(config, { code, codeVerifier, redirectUri });
   await seedOidcSession(page, tokens, config, options);
+}
+
+export async function completeMockAuthLogin(page: Page, options: BrowserLoginOptions = {}): Promise<void> {
+  const expectedEmail = options.email ?? process.env.E2E_OIDC_EMAIL ?? defaultEmail;
+  const loginHeading = page.getByRole('heading', { level: 1, name: /Log in to/ });
+  await expect(loginHeading).toBeVisible({ timeout: 30000 });
+  await fillMockAuthLoginForm(page, expectedEmail, options.onLoginPage);
 }


### PR DESCRIPTION
## Summary
- add a tracing-app deep-link OIDC callback test for unauthenticated flows
- add browser login/clear auth helpers for mock auth
- bump the default codex init image to 0.13.19

## Testing
- `go test ./...` (suites/go-core)
- `npx eslint . --config eslint.config.js` (suites/playwright-tracing-app)
- `E2E_BASE_URL=https://tracing.agyn.dev npx playwright test --grep \"@smoke\"` (suites/playwright-tracing-app) **failed**: connect ECONNREFUSED 127.0.0.1:443

## Issue
- #16