### PR TITLE
chore(e2e): bump codex init image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Optional domain override:
 
 - `E2E_DOMAIN`
 
-Full-chain tests use `AGN_INIT_IMAGE` for the agn agent init image and `CODEX_INIT_IMAGE` for codex (each falls back to the default used by go-core).
+Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:0.4.15`) for agn and
+`CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:0.13.20`) for codex.
 
 Example runs:
 

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -57,7 +57,7 @@ var (
 	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.19")
+	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.20")
 	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.15")
 )
 

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -27,7 +27,7 @@ const AGENT_IMAGE = 'alpine:3.21';
 const MCP_IMAGE = 'node:22-slim';
 const DEFAULT_INIT_IMAGES = {
   agn: 'ghcr.io/agynio/agent-init-agn:0.4.15',
-  codex: 'ghcr.io/agynio/agent-init-codex:0.13.19',
+  codex: 'ghcr.io/agynio/agent-init-codex:0.13.20',
 } as const;
 const TRACE_DISCOVER_TIMEOUT_MS = 2 * 60_000;
 const TRACE_SUMMARY_TIMEOUT_MS = 2 * 60_000;


### PR DESCRIPTION
## Summary
- bump default codex init image to 0.13.20 in go-core and tracing-app helpers
- document codex init image default in README

## Testing
- `go test ./...` (suites/go-core)
- `npx eslint . --config eslint.config.js` (suites/playwright-tracing-app)
- `E2E_BASE_URL=https://tracing.agyn.dev npx playwright test --grep \"@smoke\"` (suites/playwright-tracing-app) **failed**: connect ECONNREFUSED 127.0.0.1:443

## Issue
- #55