### PR TITLE
feat(tracing-app): add claude full-chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Optional domain override:
 
 - `E2E_DOMAIN`
 
-Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:0.4.15`) for agn and
-`CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:0.13.20`) for codex.
+Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:0.4.15`) for agn,
+`CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:0.13.20`) for codex, and
+`CLAUDE_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-claude:0.1.23`) for claude.
 
 Example runs:
 

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -261,7 +261,7 @@ EOF
       fi
     done
 
-    for env_name in CODEX_INIT_IMAGE AGN_INIT_IMAGE AGN_EXPOSE_INIT_IMAGE; do
+    for env_name in CODEX_INIT_IMAGE AGN_INIT_IMAGE CLAUDE_INIT_IMAGE AGN_EXPOSE_INIT_IMAGE; do
       env_value=${!env_name:-}
       if [ -n "$env_value" ]; then
         exec_env+=("${env_name}=${env_value}")

--- a/suites/playwright-tracing-app/test/e2e/message-deeplink-fullchain-claude.spec.ts
+++ b/suites/playwright-tracing-app/test/e2e/message-deeplink-fullchain-claude.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from './fixtures';
+import { createFullChainRun } from './tracing-run';
+
+test.describe('message deep link full chain claude', { tag: ['@svc_tracing_app', '@svc_agents_orchestrator'] }, () => {
+  test('resolves message to run and renders timeline', async ({ page }) => {
+    test.setTimeout(8 * 60_000);
+    const run = await createFullChainRun(page, { sdk: 'claude' });
+
+    await page.goto(`/message/${run.messageId}?orgId=${run.organizationId}`);
+
+    const runUrlPattern = new RegExp(`/${run.organizationId}/runs/[0-9a-f]{32}(\\?.*)?$`);
+    await expect(page).toHaveURL(runUrlPattern, { timeout: 60000 });
+
+    const currentUrl = new URL(page.url());
+    const runIdFromUrl = currentUrl.pathname.split('/').pop();
+    if (!runIdFromUrl || !/^[0-9a-f]{32}$/i.test(runIdFromUrl)) {
+      throw new Error(`Run redirect URL did not include a run id: ${page.url()}`);
+    }
+    expect(runIdFromUrl).toBe(run.runId);
+
+    await expect(page.getByTestId('run-summary-status')).toContainText(/finished/i, { timeout: 120000 });
+
+    const eventsList = page.getByTestId('run-events-list');
+    await expect(eventsList).toBeVisible();
+    const eventItems = eventsList.locator('[data-testid^="run-event-"]');
+    await expect.poll(() => eventItems.count(), { timeout: 120000 }).toBeGreaterThanOrEqual(5);
+
+    await expect(eventsList.getByRole('button', { name: /create_entities/ })).toBeVisible();
+    await expect(eventsList.getByRole('button', { name: /list_directory/ })).toBeVisible();
+
+    const messageEvent = eventsList.getByRole('button', { name: /Message • Source/ }).first();
+    await messageEvent.click();
+    await expect(page.getByTestId('run-event-details-message-content')).toContainText(run.prompt);
+
+    const llmEvents = eventsList.getByRole('button', { name: /LLM Call/ });
+    const llmCount = await llmEvents.count();
+    if (llmCount === 0) {
+      throw new Error('Expected at least one LLM call event in the timeline.');
+    }
+    await llmEvents.nth(llmCount - 1).click();
+    await expect(page.getByTestId('run-event-details-llm-output')).toContainText(run.expectedResponse);
+  });
+});

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -20,15 +20,29 @@ import {
 const TEST_LLM_ENDPOINTS = {
   agn: 'https://testllm.dev/v1/org/agynio/suite/agn/responses',
   codex: 'https://testllm.dev/v1/org/agynio/suite/codex/responses',
+  claude: 'https://testllm.dev/v1/org/agynio/suite/claude/messages',
 } as const;
+type TraceSdk = keyof typeof TEST_LLM_ENDPOINTS;
+
+const TEST_LLM_PROTOCOLS: Record<TraceSdk, string> = {
+  agn: 'PROTOCOL_RESPONSES',
+  codex: 'PROTOCOL_RESPONSES',
+  claude: 'PROTOCOL_ANTHROPIC_MESSAGES',
+};
 const TEST_LLM_TOKEN = 'test-token';
 const TEST_LLM_MODEL = 'mcp-tools-test';
 const AGENT_IMAGE = 'alpine:3.21';
 const MCP_IMAGE = 'node:22-slim';
-const DEFAULT_INIT_IMAGES = {
+const DEFAULT_INIT_IMAGES: Record<TraceSdk, string> = {
   agn: 'ghcr.io/agynio/agent-init-agn:0.4.15',
   codex: 'ghcr.io/agynio/agent-init-codex:0.13.20',
-} as const;
+  claude: 'ghcr.io/agynio/agent-init-claude:0.1.23',
+};
+const INIT_IMAGE_OVERRIDES: Record<TraceSdk, string | undefined> = {
+  agn: process.env.AGN_INIT_IMAGE?.trim(),
+  codex: process.env.CODEX_INIT_IMAGE?.trim(),
+  claude: process.env.CLAUDE_INIT_IMAGE?.trim(),
+};
 const TRACE_DISCOVER_TIMEOUT_MS = 2 * 60_000;
 const TRACE_SUMMARY_TIMEOUT_MS = 2 * 60_000;
 const TRACE_POLL_INTERVAL_MS = 1_000;
@@ -57,19 +71,21 @@ export type FullChainRun = {
   expectedResponse: string;
 };
 
-type TraceSdk = keyof typeof TEST_LLM_ENDPOINTS;
-
 type FullChainRunOptions = {
   sdk?: TraceSdk;
 };
 
 function resolveInitImage(sdk: TraceSdk): string {
-  const override = sdk === 'codex' ? process.env.CODEX_INIT_IMAGE?.trim() : process.env.AGN_INIT_IMAGE?.trim();
+  const override = INIT_IMAGE_OVERRIDES[sdk];
   return override || DEFAULT_INIT_IMAGES[sdk];
 }
 
 function resolveLlmEndpoint(sdk: TraceSdk): string {
   return TEST_LLM_ENDPOINTS[sdk];
+}
+
+function resolveLlmProtocol(sdk: TraceSdk): string {
+  return TEST_LLM_PROTOCOLS[sdk];
 }
 
 function buildMcpName(prefix: string): string {
@@ -193,7 +209,7 @@ export async function createFullChainRun(page: Page, options: FullChainRunOption
     organizationId,
     name: `e2e-${sdk}-testllm-${randomUUID()}`,
     endpoint: resolveLlmEndpoint(sdk),
-    protocol: 'PROTOCOL_RESPONSES',
+    protocol: resolveLlmProtocol(sdk),
     authMethod: 'AUTH_METHOD_BEARER',
     token: TEST_LLM_TOKEN,
   });

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -38,6 +38,11 @@ const DEFAULT_INIT_IMAGES: Record<TraceSdk, string> = {
   codex: 'ghcr.io/agynio/agent-init-codex:0.13.20',
   claude: 'ghcr.io/agynio/agent-init-claude:0.1.23',
 };
+const INIT_IMAGE_ENV_VARS: Record<TraceSdk, string> = {
+  agn: 'AGN_INIT_IMAGE',
+  codex: 'CODEX_INIT_IMAGE',
+  claude: 'CLAUDE_INIT_IMAGE',
+};
 const INIT_IMAGE_OVERRIDES: Record<TraceSdk, string | undefined> = {
   agn: process.env.AGN_INIT_IMAGE?.trim(),
   codex: process.env.CODEX_INIT_IMAGE?.trim(),
@@ -144,6 +149,7 @@ function extractCounts(counts: Record<string, number | string> | undefined): Tra
 async function waitForTraceIdByMessageId(page: Page, params: {
   organizationId: string;
   messageId: string;
+  sdk: TraceSdk;
 }): Promise<string> {
   const start = Date.now();
   let sawSpans = false;
@@ -167,9 +173,10 @@ async function waitForTraceIdByMessageId(page: Page, params: {
     await page.waitForTimeout(TRACE_POLL_INTERVAL_MS);
   }
   if (!sawSpans) {
+    const envVar = INIT_IMAGE_ENV_VARS[params.sdk];
     throw new Error(
       `ListSpans(filter: { messageId: ${params.messageId} }) returned no spans after ${TRACE_DISCOVER_TIMEOUT_MS / 1000}s. ` +
-        'Check message-id correlation and ensure the agent init image is up to date (e.g. codex init image).',
+        `Check message-id correlation and ensure the ${params.sdk} agent init image is up to date (override via ${envVar}).`,
     );
   }
   throw new Error(`Timed out waiting for trace id for message ${params.messageId}.`);
@@ -266,7 +273,7 @@ export async function createFullChainRun(page: Page, options: FullChainRunOption
     body: MCP_TOOLS_PROMPT,
   });
 
-  const runId = await waitForTraceIdByMessageId(page, { organizationId, messageId });
+  const runId = await waitForTraceIdByMessageId(page, { organizationId, messageId, sdk });
   await waitForTraceSummary(page, runId);
 
   return {


### PR DESCRIPTION
## Summary
- add Claude full-chain TestLLM/protocol/init image support in tracing helper
- add Claude message deep link full-chain spec
- document CLAUDE_INIT_IMAGE default
- forward CLAUDE_INIT_IMAGE into suite runner env

## Testing
- npx eslint . --config eslint.config.js
- E2E_BASE_URL=https://tracing.agyn.dev npx playwright test (fails: connect ECONNREFUSED 127.0.0.1:443 for /env.js)

Closes #60