### PR TITLE
Update init image defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Optional domain override:
 Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:0.4`) for agn,
 `CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:0.13`) for codex, and
 `CLAUDE_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-claude:0.1`) for claude.
+For exact reproducibility, set `*_INIT_IMAGE` to a pinned patch tag
+(for example, `ghcr.io/agynio/agent-init-agn:0.4.15`) or an image digest
+(for example, `ghcr.io/agynio/agent-init-agn@sha256:<digest>`).
 
 Example runs:
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Optional domain override:
 
 - `E2E_DOMAIN`
 
-Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:0.4.15`) for agn,
-`CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:0.13.20`) for codex, and
-`CLAUDE_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-claude:0.1.23`) for claude.
+Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:0.4`) for agn,
+`CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:0.13`) for codex, and
+`CLAUDE_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-claude:0.1`) for claude.
 
 Example runs:
 

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -36,7 +36,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.15")
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -57,8 +57,8 @@ var (
 	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.20")
-	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.15")
+	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13")
+	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4")
 )
 
 type pipelineRun struct {

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -12,7 +12,7 @@ const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
 export const DEFAULT_TEST_INIT_IMAGE =
   process.env.E2E_AGENT_INIT_IMAGE ??
   process.env.CODEX_INIT_IMAGE ??
-  'ghcr.io/agynio/agent-init-codex:0.13.19';
+  'ghcr.io/agynio/agent-init-codex:0.13';
 
 export const DEFAULT_TEST_AGENT_IMAGE = 'alpine:3.21';
 

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -34,9 +34,9 @@ const TEST_LLM_MODEL = 'mcp-tools-test';
 const AGENT_IMAGE = 'alpine:3.21';
 const MCP_IMAGE = 'node:22-slim';
 const DEFAULT_INIT_IMAGES: Record<TraceSdk, string> = {
-  agn: 'ghcr.io/agynio/agent-init-agn:0.4.15',
-  codex: 'ghcr.io/agynio/agent-init-codex:0.13.20',
-  claude: 'ghcr.io/agynio/agent-init-claude:0.1.23',
+  agn: 'ghcr.io/agynio/agent-init-agn:0.4',
+  codex: 'ghcr.io/agynio/agent-init-codex:0.13',
+  claude: 'ghcr.io/agynio/agent-init-claude:0.1',
 };
 const INIT_IMAGE_ENV_VARS: Record<TraceSdk, string> = {
   agn: 'AGN_INIT_IMAGE',


### PR DESCRIPTION
## Summary
- switch default agent init images to floating major.minor tags
- align go-core and Playwright suites with new defaults

## Testing
- go test ./...
- npx eslint . --config eslint.config.js

Closes #62