### PR TITLE
Require explicit init images

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -172,29 +172,25 @@ runs:
           echo "AGYN_AGENT_IMAGE=$AGYN_AGENT_IMAGE" >> "$GITHUB_ENV"
         fi
 
-        if [ -z "${AGYN_AGENT_INIT_IMAGE:-}" ]; then
-          AGYN_AGENT_INIT_IMAGE="ghcr.io/agynio/agent-init:v1.0.0"
-          echo "AGYN_AGENT_INIT_IMAGE=$AGYN_AGENT_INIT_IMAGE" >> "$GITHUB_ENV"
-        fi
-
-        if [ -z "${CODEX_INIT_IMAGE:-}" ]; then
-          CODEX_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:0.13"
-          echo "CODEX_INIT_IMAGE=$CODEX_INIT_IMAGE" >> "$GITHUB_ENV"
-        fi
-
-        if [ -z "${AGN_INIT_IMAGE:-}" ]; then
-          AGN_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.4"
-          echo "AGN_INIT_IMAGE=$AGN_INIT_IMAGE" >> "$GITHUB_ENV"
-        fi
-
-        if [ -z "${CLAUDE_INIT_IMAGE:-}" ]; then
-          CLAUDE_INIT_IMAGE="ghcr.io/agynio/agent-init-claude:0.1"
-          echo "CLAUDE_INIT_IMAGE=$CLAUDE_INIT_IMAGE" >> "$GITHUB_ENV"
-        fi
-
-        if [ -z "${AGN_EXPOSE_INIT_IMAGE:-}" ]; then
-          AGN_EXPOSE_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.4"
-          echo "AGN_EXPOSE_INIT_IMAGE=$AGN_EXPOSE_INIT_IMAGE" >> "$GITHUB_ENV"
+        required_init_envs=(
+          AGYN_AGENT_INIT_IMAGE
+          CODEX_INIT_IMAGE
+          AGN_INIT_IMAGE
+          CLAUDE_INIT_IMAGE
+          AGN_EXPOSE_INIT_IMAGE
+        )
+        missing_init_envs=()
+        for env_name in "${required_init_envs[@]}"; do
+          env_value=${!env_name:-}
+          trimmed_value=$(echo "$env_value" | xargs)
+          if [ -z "$trimmed_value" ]; then
+            missing_init_envs+=("$env_name")
+          fi
+        done
+        if [ "${#missing_init_envs[@]}" -gt 0 ]; then
+          printf 'Missing required init image environment variables: %s\n' \
+            "${missing_init_envs[*]}" >&2
+          exit 1
         fi
 
         if [ -z "${AGYN_MODEL_ID:-}" ]; then

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -177,6 +177,26 @@ runs:
           echo "AGYN_AGENT_INIT_IMAGE=$AGYN_AGENT_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 
+        if [ -z "${CODEX_INIT_IMAGE:-}" ]; then
+          CODEX_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:0.13"
+          echo "CODEX_INIT_IMAGE=$CODEX_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
+        if [ -z "${AGN_INIT_IMAGE:-}" ]; then
+          AGN_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.4"
+          echo "AGN_INIT_IMAGE=$AGN_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
+        if [ -z "${CLAUDE_INIT_IMAGE:-}" ]; then
+          CLAUDE_INIT_IMAGE="ghcr.io/agynio/agent-init-claude:0.1"
+          echo "CLAUDE_INIT_IMAGE=$CLAUDE_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
+        if [ -z "${AGN_EXPOSE_INIT_IMAGE:-}" ]; then
+          AGN_EXPOSE_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.4"
+          echo "AGN_EXPOSE_INIT_IMAGE=$AGN_EXPOSE_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
         if [ -z "${AGYN_MODEL_ID:-}" ]; then
           list_models_payload=$(cat <<EOF
         {"organizationId":"${AGYN_ORGANIZATION_ID}","llmProviderId":"","pageSize":200,"pageToken":""}

--- a/.github/workflows/agn-cli-e2e.yml
+++ b/.github/workflows/agn-cli-e2e.yml
@@ -11,6 +11,12 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+    env:
+      AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
+      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
+      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/agn-cli-e2e.yml
+++ b/.github/workflows/agn-cli-e2e.yml
@@ -55,9 +55,9 @@ jobs:
           chmod +x agn
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@0382a86ed54c603a30cceb91e2fe4eba8c2fd924
+        uses: agynio/bootstrap/.github/actions/provision@main
         with:
-          ref: 0382a86ed54c603a30cceb91e2fe4eba8c2fd924
+          ref: main
 
       - name: Run go-agn-cli suite
         uses: ./.github/actions/run-tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,12 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+    env:
+      AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
+      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
+      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@cb90c2fdeaf59facdb883ce8597e2099de51e8c6
+        uses: agynio/bootstrap/.github/actions/provision@main
         with:
-          ref: cb90c2fdeaf59facdb883ce8597e2099de51e8c6
+          ref: main
 
       - name: Run E2E tests
         uses: ./.github/actions/run-tests

--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ Optional domain override:
 
 - `E2E_DOMAIN`
 
-Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:0.4`) for agn,
-`CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:0.13`) for codex, and
-`CLAUDE_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-claude:0.1`) for claude.
-For exact reproducibility, set `*_INIT_IMAGE` to a pinned patch tag
+Full-chain tests require explicit init images:
+
+- `AGN_INIT_IMAGE` (agn, for example `ghcr.io/agynio/agent-init-agn:0.4`)
+- `CODEX_INIT_IMAGE` (codex, for example `ghcr.io/agynio/agent-init-codex:0.13`)
+- `CLAUDE_INIT_IMAGE` (claude, for example `ghcr.io/agynio/agent-init-claude:0.1`)
+- `AGN_EXPOSE_INIT_IMAGE` (go-core expose tests, for example `ghcr.io/agynio/agent-init-agn:0.4`)
+
+For exact reproducibility, pin `*_INIT_IMAGE` to a patch tag
 (for example, `ghcr.io/agynio/agent-init-agn:0.4.15`) or an image digest
 (for example, `ghcr.io/agynio/agent-init-agn@sha256:<digest>`).
 

--- a/scripts/parse_suite.py
+++ b/scripts/parse_suite.py
@@ -26,7 +26,7 @@ def parse_suite(path: str) -> dict[str, str]:
     if not isinstance(data, dict):
         raise ValueError(f"Suite file {path} must define a YAML mapping at the top level.")
 
-    allowed_keys = {"image", "workdir", "select", "run", "manifests", "service_account"}
+    allowed_keys = {"image", "workdir", "select", "run", "manifests", "service_account", "required_env"}
     required_keys = {"image", "select", "run"}
     unknown_keys = set(data.keys()) - allowed_keys
     if unknown_keys:
@@ -55,6 +55,20 @@ def parse_suite(path: str) -> dict[str, str]:
                 value = "\n".join(entries)
             elif not isinstance(value, str):
                 raise ValueError(f"Value for '{key}' in {path} must be a string or list of strings.")
+        elif key == "required_env":
+            if value is None or value == "":
+                value = ""
+            elif isinstance(value, list):
+                entries: list[str] = []
+                for entry in value:
+                    if not isinstance(entry, str):
+                        raise ValueError(f"Required env entries in {path} must be strings.")
+                    trimmed = entry.strip()
+                    if trimmed:
+                        entries.append(trimmed)
+                value = "\n".join(entries)
+            else:
+                raise ValueError(f"Value for '{key}' in {path} must be a list of strings.")
         else:
             if value is None:
                 value = ""
@@ -81,7 +95,7 @@ def main() -> int:
         return 1
     os.makedirs(output_dir, exist_ok=True)
 
-    for key in ("image", "workdir", "select", "run", "manifests", "service_account"):
+    for key in ("image", "workdir", "select", "run", "manifests", "service_account", "required_env"):
         value = data.get(key, "")
         output_path = os.path.join(output_dir, key)
         with open(output_path, "w", encoding="utf-8") as handle:

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -106,6 +106,7 @@ PY
     run_file="$tmp_dir/run"
     manifests_file="$tmp_dir/manifests"
     service_account_file="$tmp_dir/service_account"
+    required_env_file="$tmp_dir/required_env"
 
     service_account=""
     if [ -s "$service_account_file" ]; then
@@ -153,6 +154,32 @@ PY
     if [ -z "$(echo "$select_output" | tr -d '[:space:]')" ]; then
       echo "Skipping suite $suite_name (no matching tests)."
       exit 0
+    fi
+
+    required_envs=()
+    if [ -s "$required_env_file" ]; then
+      while IFS= read -r env_name || [ -n "$env_name" ]; do
+        trimmed=$(echo "$env_name" | xargs)
+        if [ -n "$trimmed" ]; then
+          required_envs+=("$trimmed")
+        fi
+      done < "$required_env_file"
+    fi
+
+    if [ "${#required_envs[@]}" -gt 0 ]; then
+      missing_envs=()
+      for env_name in "${required_envs[@]}"; do
+        env_value=${!env_name:-}
+        trimmed_value=$(echo "$env_value" | xargs)
+        if [ -z "$trimmed_value" ]; then
+          missing_envs+=("$env_name")
+        fi
+      done
+      if [ "${#missing_envs[@]}" -gt 0 ]; then
+        printf 'ERROR: suite %s missing required environment variables: %s\n' \
+          "$suite_name" "${missing_envs[*]}" >&2
+        exit 1
+      fi
     fi
 
     manifest_files=()

--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -3,6 +3,10 @@ workdir: /opt/app/data
 manifests:
   - manifests/agents-orchestrator
 service_account: agents-orchestrator-e2e
+required_env:
+  - AGN_INIT_IMAGE
+  - CODEX_INIT_IMAGE
+  - AGN_EXPOSE_INIT_IMAGE
 select: |
   suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "svc_organizations" "svc_files" "svc_gateway" "svc_media_proxy" "smoke")
 

--- a/suites/go-core/tests/env_helpers_test.go
+++ b/suites/go-core/tests/env_helpers_test.go
@@ -3,9 +3,22 @@
 package tests
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
+
+func requireEnv(key string) string {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		panic(fmt.Sprintf("Missing required environment variable %s", key))
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		panic(fmt.Sprintf("Missing required environment variable %s", key))
+	}
+	return trimmed
+}
 
 func envOrDefault(key, fallback string) string {
 	value, ok := os.LookupEnv(key)

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -36,7 +36,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4")
+	exposeInitImage := requireEnv("AGN_EXPOSE_INIT_IMAGE")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -57,8 +57,8 @@ var (
 	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13")
-	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4")
+	codexInitImage = requireEnv("CODEX_INIT_IMAGE")
+	agnInitImage   = requireEnv("AGN_INIT_IMAGE")
 )
 
 type pipelineRun struct {
@@ -141,6 +141,9 @@ func createAgent(t *testing.T, ctx context.Context, client agentsv1.AgentsServic
 
 func createAgentWithIdleTimeout(t *testing.T, ctx context.Context, client agentsv1.AgentsServiceClient, name, model, organizationID, initImage, idleTimeout string) *agentsv1.Agent {
 	t.Helper()
+	if strings.TrimSpace(initImage) == "" {
+		t.Fatal("create agent: init image is required")
+	}
 	request := &agentsv1.CreateAgentRequest{
 		Name:           name,
 		Role:           "assistant",

--- a/suites/playwright-chat-app/suite.yaml
+++ b/suites/playwright-chat-app/suite.yaml
@@ -1,5 +1,7 @@
 image: mcr.microsoft.com/playwright:v1.59.1-noble
 workdir: /opt/app/data
+required_env:
+  - CODEX_INIT_IMAGE
 select: |
   suite_tags=("svc_chat_app" "svc_gateway" "svc_agents_orchestrator" "svc_organizations" "svc_files" "svc_media_proxy")
 

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -9,11 +9,6 @@ const LLM_GATEWAY_PATH = '/api/agynio.api.gateway.v1.LLMGateway';
 const ORGS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.OrganizationsGateway';
 const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
 
-export const DEFAULT_TEST_INIT_IMAGE =
-  process.env.E2E_AGENT_INIT_IMAGE ??
-  process.env.CODEX_INIT_IMAGE ??
-  'ghcr.io/agynio/agent-init-codex:0.13';
-
 export const DEFAULT_TEST_AGENT_IMAGE = 'alpine:3.21';
 
 const DEFAULT_CLUSTER_ADMIN_IDENTITY_ID = 'a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10';
@@ -23,6 +18,21 @@ const CONNECT_HEADERS = {
   'Content-Type': 'application/json',
   'Connect-Protocol-Version': '1',
 };
+
+export function resolveCodexInitImage(override?: string): string {
+  if (override !== undefined) {
+    const trimmed = override.trim();
+    if (!trimmed) {
+      throw new Error('initImage is required to create chat agents.');
+    }
+    return trimmed;
+  }
+  const value = process.env.CODEX_INIT_IMAGE?.trim() ?? '';
+  if (!value) {
+    throw new Error('CODEX_INIT_IMAGE is required to create chat agents.');
+  }
+  return value;
+}
 
 type CreateChatResponseWire = {
   chat?: { id?: string };
@@ -476,7 +486,11 @@ async function waitForAgent(page: Page, organizationId: string, agentId: string)
 
 export async function createAgent(page: Page, opts: CreateAgentOptions): Promise<string> {
   const { initImage, ...rest } = opts;
-  const payload = { ...rest, initImage };
+  const trimmedInitImage = initImage.trim();
+  if (!trimmedInitImage) {
+    throw new Error('initImage is required to create chat agents.');
+  }
+  const payload = { ...rest, initImage: trimmedInitImage };
   const response = await postConnect<CreateAgentResponseWire>(
     page,
     AGENTS_GATEWAY_PATH,
@@ -521,7 +535,7 @@ export async function setupTestAgent(
 ): Promise<{ organizationId: string; agentId: string; agentName: string; participantId: string }> {
   const now = Date.now();
   const organizationId = await createOrganization(page, `e2e-org-llm-${now}`);
-  const initImage = opts.initImage ?? DEFAULT_TEST_INIT_IMAGE;
+  const initImage = resolveCodexInitImage(opts.initImage);
   const apiToken = await createApiToken(page, `e2e-agent-token-${now}`);
 
   const { modelId } = await createTestModel(page, {

--- a/suites/playwright-chat-app/test/e2e/chats-list.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chats-list.spec.ts
@@ -7,8 +7,8 @@ import {
   createOrganization,
   createTestModel,
   DEFAULT_TEST_AGENT_IMAGE,
-  DEFAULT_TEST_INIT_IMAGE,
   resolveIdentityId,
+  resolveCodexInitImage,
 } from './chat-api';
 import { setSelectedOrganization } from './organization-helpers';
 
@@ -56,7 +56,7 @@ test.describe('chats-list', { tag: ['@svc_chat_app', '@svc_gateway', '@svc_organ
         description: 'E2E participant picker agent',
         configuration: '{}',
         image: DEFAULT_TEST_AGENT_IMAGE,
-        initImage: DEFAULT_TEST_INIT_IMAGE,
+        initImage: resolveCodexInitImage(process.env.E2E_AGENT_INIT_IMAGE),
       });
       const chatsLoaded = userAPage.waitForResponse(
         (resp) => resp.url().includes('GetChats') && resp.status() === 200,

--- a/suites/playwright-chat-app/test/e2e/organization-switching.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/organization-switching.spec.ts
@@ -6,7 +6,7 @@ import {
   createOrganization,
   createTestModel,
   DEFAULT_TEST_AGENT_IMAGE,
-  DEFAULT_TEST_INIT_IMAGE,
+  resolveCodexInitImage,
 } from './chat-api';
 import { setSelectedOrganization } from './organization-helpers';
 
@@ -27,7 +27,7 @@ async function createAgentForOrg(page: Page, organizationId: string, name: strin
     description: 'Org switch agent',
     configuration: '{}',
     image: DEFAULT_TEST_AGENT_IMAGE,
-    initImage: DEFAULT_TEST_INIT_IMAGE,
+    initImage: resolveCodexInitImage(process.env.E2E_AGENT_INIT_IMAGE),
   });
 }
 

--- a/suites/playwright-tracing-app/suite.yaml
+++ b/suites/playwright-tracing-app/suite.yaml
@@ -1,5 +1,9 @@
 image: mcr.microsoft.com/playwright:v1.59.1-noble
 workdir: /opt/app/data
+required_env:
+  - AGN_INIT_IMAGE
+  - CODEX_INIT_IMAGE
+  - CLAUDE_INIT_IMAGE
 select: |
   suite_tags=("svc_tracing_app" "svc_agents_orchestrator" "smoke")
 

--- a/suites/playwright-tracing-app/test/e2e/gateway-api.ts
+++ b/suites/playwright-tracing-app/test/e2e/gateway-api.ts
@@ -199,12 +199,16 @@ export async function createAgent(page: Page, params: {
   role?: string;
   configuration?: string;
 }): Promise<string> {
+  const initImage = params.initImage.trim();
+  if (!initImage) {
+    throw new Error('initImage is required to create agents.');
+  }
   const payload: Record<string, unknown> = {
     organizationId: params.organizationId,
     name: params.name,
     model: params.model,
     image: params.image,
-    initImage: params.initImage,
+    initImage,
     role: params.role ?? 'assistant',
   };
   if (params.description !== undefined) {

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -33,20 +33,10 @@ const TEST_LLM_TOKEN = 'test-token';
 const TEST_LLM_MODEL = 'mcp-tools-test';
 const AGENT_IMAGE = 'alpine:3.21';
 const MCP_IMAGE = 'node:22-slim';
-const DEFAULT_INIT_IMAGES: Record<TraceSdk, string> = {
-  agn: 'ghcr.io/agynio/agent-init-agn:0.4',
-  codex: 'ghcr.io/agynio/agent-init-codex:0.13',
-  claude: 'ghcr.io/agynio/agent-init-claude:0.1',
-};
 const INIT_IMAGE_ENV_VARS: Record<TraceSdk, string> = {
   agn: 'AGN_INIT_IMAGE',
   codex: 'CODEX_INIT_IMAGE',
   claude: 'CLAUDE_INIT_IMAGE',
-};
-const INIT_IMAGE_OVERRIDES: Record<TraceSdk, string | undefined> = {
-  agn: process.env.AGN_INIT_IMAGE?.trim(),
-  codex: process.env.CODEX_INIT_IMAGE?.trim(),
-  claude: process.env.CLAUDE_INIT_IMAGE?.trim(),
 };
 const TRACE_DISCOVER_TIMEOUT_MS = 2 * 60_000;
 const TRACE_SUMMARY_TIMEOUT_MS = 2 * 60_000;
@@ -81,8 +71,12 @@ type FullChainRunOptions = {
 };
 
 function resolveInitImage(sdk: TraceSdk): string {
-  const override = INIT_IMAGE_OVERRIDES[sdk];
-  return override || DEFAULT_INIT_IMAGES[sdk];
+  const envVar = INIT_IMAGE_ENV_VARS[sdk];
+  const value = process.env[envVar]?.trim() ?? '';
+  if (!value) {
+    throw new Error(`${envVar} is required to run tracing full-chain tests.`);
+  }
+  return value;
 }
 
 function resolveLlmEndpoint(sdk: TraceSdk): string {


### PR DESCRIPTION
## Summary
- add required_env support to suite parsing and enforce required envs in the pipeline
- remove init image fallbacks in Go/Playwright tests and guard against blank initImage
- document required init image envs and set explicit values in CI

## Testing
- go test ./...
- npx eslint . --config eslint.config.js

Closes #66