### PR TITLE
test(go-core): use hello in retry

### DIFF
--- a/suites/go-core/tests/workload_start_retry_policy_test.go
+++ b/suites/go-core/tests/workload_start_retry_policy_test.go
@@ -89,7 +89,7 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 	}
 	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
-	sentMessage := sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "e2e workload start retry")
+	sentMessage := sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "hello")
 	sentMessageTime := messageCreatedAt(t, sentMessage)
 
 	labels := map[string]string{


### PR DESCRIPTION
## Summary
- send a simple hello message in the workload start retry test to match the TestLLM simple-hello fixture

## Testing
- go test ./...
- go vet -p 1 ./...

Refs #144