### PR TITLE
chore(e2e): default init images to latest

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -172,14 +172,15 @@ runs:
           echo "AGYN_AGENT_IMAGE=$AGYN_AGENT_IMAGE" >> "$GITHUB_ENV"
         fi
 
-        if [ -z "${AGYN_AGENT_INIT_IMAGE:-}" ]; then
-          AGYN_AGENT_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:latest"
-          echo "AGYN_AGENT_INIT_IMAGE=$AGYN_AGENT_INIT_IMAGE" >> "$GITHUB_ENV"
-        fi
-
         if [ -z "${CODEX_INIT_IMAGE:-}" ]; then
           CODEX_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:latest"
           echo "CODEX_INIT_IMAGE=$CODEX_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
+        if [ -z "${AGYN_AGENT_INIT_IMAGE:-}" ]; then
+          # No agynio/agent-init image exists; default to the codex init image.
+          AGYN_AGENT_INIT_IMAGE="$CODEX_INIT_IMAGE"
+          echo "AGYN_AGENT_INIT_IMAGE=$AGYN_AGENT_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 
         if [ -z "${AGN_INIT_IMAGE:-}" ]; then

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -172,25 +172,29 @@ runs:
           echo "AGYN_AGENT_IMAGE=$AGYN_AGENT_IMAGE" >> "$GITHUB_ENV"
         fi
 
-        required_init_envs=(
-          AGYN_AGENT_INIT_IMAGE
-          CODEX_INIT_IMAGE
-          AGN_INIT_IMAGE
-          CLAUDE_INIT_IMAGE
-          AGN_EXPOSE_INIT_IMAGE
-        )
-        missing_init_envs=()
-        for env_name in "${required_init_envs[@]}"; do
-          env_value=${!env_name:-}
-          trimmed_value=$(echo "$env_value" | xargs)
-          if [ -z "$trimmed_value" ]; then
-            missing_init_envs+=("$env_name")
-          fi
-        done
-        if [ "${#missing_init_envs[@]}" -gt 0 ]; then
-          printf 'Missing required init image environment variables: %s\n' \
-            "${missing_init_envs[*]}" >&2
-          exit 1
+        if [ -z "${AGYN_AGENT_INIT_IMAGE:-}" ]; then
+          AGYN_AGENT_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:latest"
+          echo "AGYN_AGENT_INIT_IMAGE=$AGYN_AGENT_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
+        if [ -z "${CODEX_INIT_IMAGE:-}" ]; then
+          CODEX_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:latest"
+          echo "CODEX_INIT_IMAGE=$CODEX_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
+        if [ -z "${AGN_INIT_IMAGE:-}" ]; then
+          AGN_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:latest"
+          echo "AGN_INIT_IMAGE=$AGN_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
+        if [ -z "${CLAUDE_INIT_IMAGE:-}" ]; then
+          CLAUDE_INIT_IMAGE="ghcr.io/agynio/agent-init-claude:latest"
+          echo "CLAUDE_INIT_IMAGE=$CLAUDE_INIT_IMAGE" >> "$GITHUB_ENV"
+        fi
+
+        if [ -z "${AGN_EXPOSE_INIT_IMAGE:-}" ]; then
+          AGN_EXPOSE_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:latest"
+          echo "AGN_EXPOSE_INIT_IMAGE=$AGN_EXPOSE_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 
         if [ -z "${AGYN_MODEL_ID:-}" ]; then

--- a/README.md
+++ b/README.md
@@ -19,14 +19,11 @@ Optional domain override:
 
 - `E2E_DOMAIN`
 
-Full-chain tests require explicit init images:
-
-- `AGN_INIT_IMAGE` (agn, for example `ghcr.io/agynio/agent-init-agn:0.4`)
-- `CODEX_INIT_IMAGE` (codex, for example `ghcr.io/agynio/agent-init-codex:0.13`)
-- `CLAUDE_INIT_IMAGE` (claude, for example `ghcr.io/agynio/agent-init-claude:0.1`)
-- `AGN_EXPOSE_INIT_IMAGE` (go-core expose tests, for example `ghcr.io/agynio/agent-init-agn:0.4`)
-
-For exact reproducibility, pin `*_INIT_IMAGE` to a patch tag
+Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:latest`) for agn,
+`CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:latest`) for codex,
+`CLAUDE_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-claude:latest`) for claude,
+and `AGN_EXPOSE_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:latest`) for go-core expose.
+For exact reproducibility, set `*_INIT_IMAGE` to a pinned patch tag
 (for example, `ghcr.io/agynio/agent-init-agn:0.4.15`) or an image digest
 (for example, `ghcr.io/agynio/agent-init-agn@sha256:<digest>`).
 

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -36,7 +36,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := requireEnv("AGN_EXPOSE_INIT_IMAGE")
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:latest")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -57,8 +57,8 @@ var (
 	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = requireEnv("CODEX_INIT_IMAGE")
-	agnInitImage   = requireEnv("AGN_INIT_IMAGE")
+	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:latest")
+	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:latest")
 )
 
 type pipelineRun struct {

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -9,6 +9,10 @@ const LLM_GATEWAY_PATH = '/api/agynio.api.gateway.v1.LLMGateway';
 const ORGS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.OrganizationsGateway';
 const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
 
+export const DEFAULT_TEST_INIT_IMAGE =
+  process.env.E2E_AGENT_INIT_IMAGE?.trim() ||
+  process.env.CODEX_INIT_IMAGE?.trim() ||
+  'ghcr.io/agynio/agent-init-codex:latest';
 export const DEFAULT_TEST_AGENT_IMAGE = 'alpine:3.21';
 
 const CONNECT_HEADERS = {
@@ -24,11 +28,11 @@ export function resolveCodexInitImage(override?: string): string {
     }
     return trimmed;
   }
-  const value = process.env.CODEX_INIT_IMAGE?.trim() ?? '';
-  if (!value) {
-    throw new Error('CODEX_INIT_IMAGE is required to create chat agents.');
+  const value = process.env.CODEX_INIT_IMAGE?.trim();
+  if (value) {
+    return value;
   }
-  return value;
+  return DEFAULT_TEST_INIT_IMAGE;
 }
 
 type CreateChatResponseWire = {

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -33,6 +33,11 @@ const TEST_LLM_TOKEN = 'test-token';
 const TEST_LLM_MODEL = 'mcp-tools-test';
 const AGENT_IMAGE = 'alpine:3.21';
 const MCP_IMAGE = 'node:22-slim';
+const DEFAULT_INIT_IMAGES: Record<TraceSdk, string> = {
+  agn: 'ghcr.io/agynio/agent-init-agn:latest',
+  codex: 'ghcr.io/agynio/agent-init-codex:latest',
+  claude: 'ghcr.io/agynio/agent-init-claude:latest',
+};
 const INIT_IMAGE_ENV_VARS: Record<TraceSdk, string> = {
   agn: 'AGN_INIT_IMAGE',
   codex: 'CODEX_INIT_IMAGE',
@@ -72,11 +77,11 @@ type FullChainRunOptions = {
 
 function resolveInitImage(sdk: TraceSdk): string {
   const envVar = INIT_IMAGE_ENV_VARS[sdk];
-  const value = process.env[envVar]?.trim() ?? '';
-  if (!value) {
-    throw new Error(`${envVar} is required to run tracing full-chain tests.`);
+  const value = process.env[envVar]?.trim();
+  if (value) {
+    return value;
   }
-  return value;
+  return DEFAULT_INIT_IMAGES[sdk];
 }
 
 function resolveLlmEndpoint(sdk: TraceSdk): string {


### PR DESCRIPTION
## Summary
- default init image envs in the run-tests action to :latest tags
- update init image defaults in go-core and playwright suites
- refresh README defaults for init images

## Testing
- go vet ./... (suites/go-core)
- go test ./tests/... (suites/go-core)
- go vet ./... (suites/go-terraform)
- go test ./tests/... (suites/go-terraform)
- go vet -tags \"e2e svc_agn_cli\" ./tests (suites/go-agn-cli)
- go test -tags \"e2e svc_agn_cli\" -run TestDoesNotExist ./tests (suites/go-agn-cli)

Related: #75