### PR TITLE
test(playwright): add workloads + threads smoke

### DIFF
--- a/suites/playwright/suite.yaml
+++ b/suites/playwright/suite.yaml
@@ -1,16 +1,20 @@
 image: ghcr.io/agynio/e2e/playwright:v1.59.1-noble
 workdir: /opt/app/data
 select: |
+  suite_tags=("svc_console" "svc_gateway" "svc_threads" "svc_identity" "smoke")
+
   if [ -z "${TAGS:-}" ]; then
     echo "playwright"
     exit 0
   fi
 
   for tag in ${TAGS}; do
-    if [ "$tag" = "svc_console" ] || [ "$tag" = "smoke" ]; then
-      echo "$tag"
-      exit 0
-    fi
+    for suite_tag in "${suite_tags[@]}"; do
+      if [ "$tag" = "$suite_tag" ]; then
+        echo "$tag"
+        exit 0
+      fi
+    done
   done
 run: |
   set -euo pipefail

--- a/suites/playwright/test/e2e/organization-threads-smoke.spec.ts
+++ b/suites/playwright/test/e2e/organization-threads-smoke.spec.ts
@@ -28,12 +28,18 @@ test.describe('organization-threads-smoke', {
     const threadId = await createThread(page, { organizationId, participantIds: [participantId] });
     await sendThreadMessage(page, { threadId, senderId: identityId, body: 'Smoke thread message.' });
 
+    const threadsLoaded = page.waitForResponse(
+      (resp) => resp.url().includes('ListThreads') && resp.status() === 200,
+      { timeout: 20000 },
+    );
+
     await page.goto(`/organizations/${organizationId}/threads`);
-    await expect(page.getByTestId('organization-threads-table')).toBeVisible({ timeout: 15000 });
-    const row = page.getByTestId('organization-thread-row').first();
-    await expect(row).toBeVisible({ timeout: 15000 });
-    await expect(row).toContainText(threadId);
-    await expect(page.getByTestId('organization-threads-empty')).toHaveCount(0);
+    await threadsLoaded;
+    await expect(page.getByTestId('organization-threads-table')).toBeVisible({ timeout: 20000 });
+    const rows = page.getByTestId('organization-thread-row');
+    const matchingRow = rows.filter({ hasText: threadId });
+    await expect(matchingRow).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId('organization-threads-empty')).toHaveCount(0, { timeout: 20000 });
     await expect(page.getByText('Failed to load threads.')).toHaveCount(0);
     await expect(page.getByText('You do not have permission to view threads.')).toHaveCount(0);
   });

--- a/suites/playwright/test/e2e/organization-threads-smoke.spec.ts
+++ b/suites/playwright/test/e2e/organization-threads-smoke.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from './fixtures';
+import {
+  createOrganization,
+  createThread,
+  createUser,
+  getMe,
+  sendThreadMessage,
+  setSelectedOrganization,
+} from './console-api';
+
+test.describe('organization-threads-smoke', {
+  tag: ['@svc_console', '@svc_gateway', '@svc_threads', '@svc_identity', '@smoke'],
+}, () => {
+  test('threads list loads with data', async ({ page }) => {
+    const organizationId = await createOrganization(page, `e2e-org-threads-smoke-${Date.now()}`);
+    await setSelectedOrganization(page, organizationId);
+    const me = await getMe(page);
+    const identityId = me.user?.meta?.id;
+    if (!identityId) {
+      throw new Error('GetMe response missing identity id for threads smoke test.');
+    }
+
+    const participantId = await createUser(page, {
+      email: `e2e-thread-smoke-${Date.now()}@agyn.test`,
+      nickname: 'thread-smoke',
+    });
+
+    const threadId = await createThread(page, { organizationId, participantIds: [participantId] });
+    await sendThreadMessage(page, { threadId, senderId: identityId, body: 'Smoke thread message.' });
+
+    await page.goto(`/organizations/${organizationId}/threads`);
+    await expect(page.getByTestId('organization-threads-table')).toBeVisible({ timeout: 15000 });
+    const row = page.getByTestId('organization-thread-row').first();
+    await expect(row).toBeVisible({ timeout: 15000 });
+    await expect(row).toContainText(threadId);
+    await expect(page.getByTestId('organization-threads-empty')).toHaveCount(0);
+    await expect(page.getByText('Failed to load threads.')).toHaveCount(0);
+    await expect(page.getByText('You do not have permission to view threads.')).toHaveCount(0);
+  });
+});

--- a/suites/playwright/test/e2e/organization-threads-smoke.spec.ts
+++ b/suites/playwright/test/e2e/organization-threads-smoke.spec.ts
@@ -29,12 +29,13 @@ test.describe('organization-threads-smoke', {
     await sendThreadMessage(page, { threadId, senderId: identityId, body: 'Smoke thread message.' });
 
     const threadsLoaded = page.waitForResponse(
-      (resp) => resp.url().includes('ListThreads') && resp.status() === 200,
+      (resp) => resp.url().includes('ListOrganizationThreads'),
       { timeout: 20000 },
     );
 
     await page.goto(`/organizations/${organizationId}/threads`);
-    await threadsLoaded;
+    const threadsResponse = await threadsLoaded;
+    expect(threadsResponse.status()).toBe(200);
     await expect(page.getByTestId('organization-threads-table')).toBeVisible({ timeout: 20000 });
     const rows = page.getByTestId('organization-thread-row');
     const matchingRow = rows.filter({ hasText: threadId });

--- a/suites/playwright/test/e2e/organization-threads.spec.ts
+++ b/suites/playwright/test/e2e/organization-threads.spec.ts
@@ -9,7 +9,7 @@ import {
   setSelectedOrganization,
 } from './console-api';
 
-test.describe('organization-threads', { tag: ['@svc_console'] }, () => {
+test.describe('organization-threads', { tag: ['@svc_console', '@svc_gateway', '@svc_threads', '@svc_identity'] }, () => {
   test('org threads list and detail pagination', async ({ page }) => {
     const organizationId = await createOrganization(page, `e2e-org-threads-${Date.now()}`);
     await setSelectedOrganization(page, organizationId);

--- a/suites/playwright/test/e2e/workloads-layout.spec.ts
+++ b/suites/playwright/test/e2e/workloads-layout.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from './fixtures';
+import { registerRunner } from './console-api';
+
+test.describe('workloads-layout', { tag: ['@svc_console', '@svc_gateway', '@smoke'] }, () => {
+  test('workloads header lays out across columns', async ({ page }) => {
+    const runnerName = `e2e-workloads-layout-${Date.now()}`;
+    const runner = await registerRunner(page, { name: runnerName, labels: { scope: 'cluster' } });
+    const runnerId = runner.meta?.id;
+    if (!runnerId) {
+      throw new Error('RegisterRunner response missing runner id for workloads layout test.');
+    }
+
+    await page.goto(`/runners/${runnerId}`);
+    const header = page.getByTestId('runner-workloads-header');
+    await expect(header).toBeVisible({ timeout: 15000 });
+
+    const agentHeader = header.getByText('Agent', { exact: true });
+    const actionHeader = header.getByText('Action', { exact: true });
+    await expect(agentHeader).toBeVisible();
+    await expect(actionHeader).toBeVisible();
+
+    const agentBox = await agentHeader.boundingBox();
+    const actionBox = await actionHeader.boundingBox();
+    if (!agentBox || !actionBox) {
+      throw new Error('Workloads header bounding boxes missing.');
+    }
+
+    const rowOffset = Math.abs(agentBox.y - actionBox.y);
+    expect(rowOffset).toBeLessThan(4);
+    expect(actionBox.x).toBeGreaterThan(agentBox.x + 100);
+  });
+});

--- a/suites/playwright/test/e2e/workloads-layout.spec.ts
+++ b/suites/playwright/test/e2e/workloads-layout.spec.ts
@@ -12,10 +12,8 @@ test.describe('workloads-layout', { tag: ['@svc_console', '@svc_gateway', '@smok
     await header.scrollIntoViewIfNeeded();
 
     const agentHeader = header.getByRole('button', { name: 'Agent' });
-    const threadHeader = header.getByRole('button', { name: 'Thread ID' });
     const statusHeader = header.getByRole('button', { name: 'Status' });
     await expect(agentHeader).toBeVisible();
-    await expect(threadHeader).toBeVisible();
     await expect(statusHeader).toBeVisible();
 
     const agentBox = await agentHeader.boundingBox();

--- a/suites/playwright/test/e2e/workloads-layout.spec.ts
+++ b/suites/playwright/test/e2e/workloads-layout.spec.ts
@@ -12,18 +12,20 @@ test.describe('workloads-layout', { tag: ['@svc_console', '@svc_gateway', '@smok
     await header.scrollIntoViewIfNeeded();
 
     const agentHeader = header.getByRole('button', { name: 'Agent' });
-    const durationHeader = header.getByRole('button', { name: 'Duration' });
+    const threadHeader = header.getByRole('button', { name: 'Thread ID' });
+    const statusHeader = header.getByRole('button', { name: 'Status' });
     await expect(agentHeader).toBeVisible();
-    await expect(durationHeader).toBeVisible();
+    await expect(threadHeader).toBeVisible();
+    await expect(statusHeader).toBeVisible();
 
     const agentBox = await agentHeader.boundingBox();
-    const durationBox = await durationHeader.boundingBox();
-    if (!agentBox || !durationBox) {
+    const statusBox = await statusHeader.boundingBox();
+    if (!agentBox || !statusBox) {
       throw new Error('Workloads header bounding boxes missing.');
     }
 
-    const rowOffset = Math.abs(agentBox.y - durationBox.y);
-    expect(rowOffset).toBeLessThan(8);
-    expect(durationBox.x).toBeGreaterThan(agentBox.x + 150);
+    const rowOffset = Math.abs(agentBox.y - statusBox.y);
+    expect(rowOffset).toBeLessThan(24);
+    expect(statusBox.x).toBeGreaterThan(agentBox.x + 120);
   });
 });

--- a/suites/playwright/test/e2e/workloads-layout.spec.ts
+++ b/suites/playwright/test/e2e/workloads-layout.spec.ts
@@ -1,32 +1,29 @@
 import { test, expect } from './fixtures';
-import { registerRunner } from './console-api';
+import { createOrganization, setSelectedOrganization } from './console-api';
 
 test.describe('workloads-layout', { tag: ['@svc_console', '@svc_gateway', '@smoke'] }, () => {
   test('workloads header lays out across columns', async ({ page }) => {
-    const runnerName = `e2e-workloads-layout-${Date.now()}`;
-    const runner = await registerRunner(page, { name: runnerName, labels: { scope: 'cluster' } });
-    const runnerId = runner.meta?.id;
-    if (!runnerId) {
-      throw new Error('RegisterRunner response missing runner id for workloads layout test.');
-    }
+    const organizationId = await createOrganization(page, `e2e-workloads-layout-${Date.now()}`);
+    await setSelectedOrganization(page, organizationId);
 
-    await page.goto(`/runners/${runnerId}`);
-    const header = page.getByTestId('runner-workloads-header');
+    await page.goto(`/organizations/${organizationId}/activity/workloads`);
+    const header = page.getByTestId('organization-workloads-header');
     await expect(header).toBeVisible({ timeout: 15000 });
+    await header.scrollIntoViewIfNeeded();
 
-    const agentHeader = header.getByText('Agent', { exact: true });
-    const actionHeader = header.getByText('Action', { exact: true });
+    const agentHeader = header.getByRole('button', { name: 'Agent' });
+    const durationHeader = header.getByRole('button', { name: 'Duration' });
     await expect(agentHeader).toBeVisible();
-    await expect(actionHeader).toBeVisible();
+    await expect(durationHeader).toBeVisible();
 
     const agentBox = await agentHeader.boundingBox();
-    const actionBox = await actionHeader.boundingBox();
-    if (!agentBox || !actionBox) {
+    const durationBox = await durationHeader.boundingBox();
+    if (!agentBox || !durationBox) {
       throw new Error('Workloads header bounding boxes missing.');
     }
 
-    const rowOffset = Math.abs(agentBox.y - actionBox.y);
-    expect(rowOffset).toBeLessThan(4);
-    expect(actionBox.x).toBeGreaterThan(agentBox.x + 100);
+    const rowOffset = Math.abs(agentBox.y - durationBox.y);
+    expect(rowOffset).toBeLessThan(8);
+    expect(durationBox.x).toBeGreaterThan(agentBox.x + 150);
   });
 });


### PR DESCRIPTION
## Summary
- expand console Playwright suite tags for gateway/threads/identity selection
- add a workloads layout smoke check with header bounding-box assertions
- add threads list smoke coverage and retag the heavier threads test

## Testing
- npm ci (suites/playwright)
- npx buf generate (suites/playwright)
- npx tsc --noEmit (suites/playwright)
- E2E_BASE_URL=https://console.agyn.dev npx playwright test --list (suites/playwright)

Ref #84