### PR TITLE
fix(go-core): restore workload label lookup keys

### DIFF
--- a/suites/go-core/tests/agent_agyn_wait_test.go
+++ b/suites/go-core/tests/agent_agyn_wait_test.go
@@ -87,9 +87,9 @@ func TestAgentAgynCLIWaitToAnotherAgent(t *testing.T) {
 	sentMessage := sendMessage(t, threadsCtx, threadsClient, threadAID, identityID, prompt)
 	sentMessageTime := messageCreatedAt(t, sentMessage)
 	labels := map[string]string{
-		"label." + labelManagedBy: managedByValue,
-		"label." + labelAgentID:   agentAID,
-		"label." + labelThreadID:  threadAID,
+		labelManagedBy: managedByValue,
+		labelAgentID:   agentAID,
+		labelThreadID:  threadAID,
 	}
 	t.Cleanup(func() {
 		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -40,9 +40,9 @@ const (
 	testLLMEndpointCodex = "https://testllm.dev/v1/org/agynio/suite/codex/responses"
 	testLLMEndpointAgn   = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
 
-	labelManagedBy = "label.managed-by"
-	labelAgentID   = "label.agent-id"
-	labelThreadID  = "label.thread-id"
+	labelManagedBy = "managed-by"
+	labelAgentID   = "agent-id"
+	labelThreadID  = "thread-id"
 	managedByValue = "agents-orchestrator"
 )
 


### PR DESCRIPTION
Restores the shared go-core workload label constants to the actual Kubernetes label keys. The agyn wait test keeps the AdditionalProperties prefix only in its local diagnostics lookup. This fixes existing workload lookup tests broken by the previous global label-key change.