### PR TITLE
fix(go-core): force token auth for expose cli e2e

### DIFF
--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -199,6 +199,8 @@ func setupExposeTestWorkload(t *testing.T) exposeWorkloadFixture {
 	}
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	createAgentEnv(t, ctx, agentsClient, agentID, "HOME", "/tmp")
+	createAgentEnv(t, ctx, agentsClient, agentID, "AGYN_GATEWAY_URL", "http://gateway:8080")
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()


### PR DESCRIPTION
Latest agents-orchestrator e2e reached expose add, but the agent's agyn CLI call used the injected GATEWAY_ADDRESS path and arrived at expose without identity metadata, causing runners GetWorkload to fail with missing x-identity-id.\n\nFor this black-box e2e, force the expose agent's agyn CLI to use the HTTP gateway token path by setting HOME=/tmp (where agn writes ~/.agyn/credentials from LLM_API_TOKEN) and AGYN_GATEWAY_URL=http://gateway:8080. This keeps the e2e focused on expose CLI behavior instead of depending on the Ziti identity path.\n\nValidation: go test -count=0 -tags 'e2e svc_agents_orchestrator' ./tests/...