### PR TITLE
test: add Claude full pipeline e2e

### DIFF
--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -6,6 +6,7 @@ service_account: agents-orchestrator-e2e
 required_env:
   - AGN_INIT_IMAGE
   - CODEX_INIT_IMAGE
+  - CLAUDE_INIT_IMAGE
   - AGN_EXPOSE_INIT_IMAGE
 select: |
   suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "svc_organizations" "svc_files" "svc_gateway" "svc_media_proxy" "smoke")

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -37,8 +37,9 @@ const (
 	tracingSummaryTimeout  = 2 * time.Minute
 	tracingStartTimeBuffer = 30 * time.Second
 
-	testLLMEndpointCodex = "https://testllm.dev/v1/org/agynio/suite/codex/responses"
-	testLLMEndpointAgn   = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+	testLLMEndpointCodex  = "https://testllm.dev/v1/org/agynio/suite/codex/responses"
+	testLLMEndpointAgn    = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+	testLLMEndpointClaude = "https://testllm.dev/v1/org/agynio/suite/claude/messages"
 
 	labelManagedBy = "managed-by"
 	labelAgentID   = "agent-id"
@@ -47,18 +48,19 @@ const (
 )
 
 var (
-	agentsAddr     = envOrDefault("AGENTS_ADDRESS", "agents:50051")
-	threadsAddr    = envOrDefault("THREADS_ADDRESS", "threads:50051")
-	llmAddr        = envOrDefault("LLM_ADDRESS", "llm:50051")
-	meteringAddr   = envOrDefault("METERING_ADDRESS", "metering:50051")
-	usersAddr      = envOrDefault("USERS_ADDRESS", "users:50051")
-	orgsAddr       = envOrDefault("ORGANIZATIONS_ADDRESS", "organizations:50051")
-	runnerAddr     = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
-	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
-	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
-	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:latest")
-	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:latest")
+	agentsAddr      = envOrDefault("AGENTS_ADDRESS", "agents:50051")
+	threadsAddr     = envOrDefault("THREADS_ADDRESS", "threads:50051")
+	llmAddr         = envOrDefault("LLM_ADDRESS", "llm:50051")
+	meteringAddr    = envOrDefault("METERING_ADDRESS", "metering:50051")
+	usersAddr       = envOrDefault("USERS_ADDRESS", "users:50051")
+	orgsAddr        = envOrDefault("ORGANIZATIONS_ADDRESS", "organizations:50051")
+	runnerAddr      = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
+	runnersAddr     = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
+	secretsAddr     = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
+	tracingAddr     = envOrDefault("TRACING_ADDRESS", "tracing:50051")
+	codexInitImage  = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:latest")
+	agnInitImage    = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:latest")
+	claudeInitImage = envOrDefault("CLAUDE_INIT_IMAGE", "ghcr.io/agynio/agent-init-claude:latest")
 )
 
 type pipelineRun struct {
@@ -98,11 +100,17 @@ func newUserID() string {
 
 func createLLMProvider(t *testing.T, ctx context.Context, client llmv1.LLMServiceClient, endpoint, orgID string) *llmv1.LLMProvider {
 	t.Helper()
+	return createLLMProviderWithProtocol(t, ctx, client, endpoint, orgID, llmv1.Protocol_PROTOCOL_RESPONSES)
+}
+
+func createLLMProviderWithProtocol(t *testing.T, ctx context.Context, client llmv1.LLMServiceClient, endpoint, orgID string, protocol llmv1.Protocol) *llmv1.LLMProvider {
+	t.Helper()
 	resp, err := client.CreateLLMProvider(ctx, &llmv1.CreateLLMProviderRequest{
 		Endpoint:       endpoint,
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
 		Token:          "test-token",
 		OrganizationId: orgID,
+		Protocol:       protocol,
 	})
 	if err != nil {
 		t.Fatalf("create llm provider: %v", err)

--- a/suites/go-core/tests/pipeline_test.go
+++ b/suites/go-core/tests/pipeline_test.go
@@ -25,7 +25,16 @@ func TestFullPipelineAgnMessageResponse(t *testing.T) {
 	runFullPipelineMessageResponse(t, testLLMEndpointAgn, agnInitImage, "hi", "Hi! How are you?")
 }
 
+func TestFullPipelineClaudeMessageResponse(t *testing.T) {
+	runFullPipelineMessageResponseWithProtocol(t, testLLMEndpointClaude, claudeInitImage, llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES, "hello", "Hi! How are you?")
+}
+
 func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, message, expectedResponse string) pipelineRun {
+	t.Helper()
+	return runFullPipelineMessageResponseWithProtocol(t, llmEndpoint, initImage, llmv1.Protocol_PROTOCOL_RESPONSES, message, expectedResponse)
+}
+
+func runFullPipelineMessageResponseWithProtocol(t *testing.T, llmEndpoint, initImage string, protocol llmv1.Protocol, message, expectedResponse string) pipelineRun {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
@@ -50,7 +59,7 @@ func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, messag
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, llmEndpoint, orgID)
+	provider := createLLMProviderWithProtocol(t, ctx, llmClient, llmEndpoint, orgID, protocol)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")


### PR DESCRIPTION
Adds a full agents-orchestrator pipeline test for Claude:\n\nmessage -> thread -> orchestrator -> workload -> agynd -> claude -> agent response\n\nThe test uses the Anthropic Messages protocol and CLAUDE_INIT_IMAGE, alongside existing Codex and agn pipeline coverage.\n\nValidation:\n- buf generate\n- go test -run TestFullPipelineClaudeMessageResponse -tags 'e2e svc_agents_orchestrator' ./tests -count=0