### PR TITLE
test: allow filtering go-core e2e tests

### DIFF
--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -46,7 +46,13 @@ run: |
 
   tmp_json=$(mktemp)
   set +e
-  go test -count=1 -tags "${tag_args}" -json ./tests/... 2>&1 | tee "${tmp_json}"
+  go_test_args=(-count=1 -tags "${tag_args}")
+  if [ -n "${E2E_GO_TEST_RUN:-}" ]; then
+    go_test_args+=(-run "${E2E_GO_TEST_RUN}")
+  fi
+  go_test_args+=(-json ./tests/...)
+
+  go test "${go_test_args[@]}" 2>&1 | tee "${tmp_json}"
   status=${PIPESTATUS[0]}
   set -e
 


### PR DESCRIPTION
Adds optional E2E_GO_TEST_RUN support to the go-core E2E suite. This lets service workflows run a targeted full-path E2E, such as the Claude message-to-workload pipeline, without being blocked by unrelated go-core tests.