### PR TITLE
Add LLM proxy e2e coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,6 @@ Example runs:
 TAGS=smoke devspace run test-e2e
 TAGS=svc_tracing_app devspace run test-e2e
 TAGS=svc_agents_orchestrator devspace run test-e2e
+TAGS=svc_llm devspace run test-e2e
+TAGS=svc_llm_proxy devspace run test-e2e
 ```

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -12,11 +12,6 @@ tags="${TAGS:-}"
 namespace="${E2E_NAMESPACE:-${DEVSPACE_NAMESPACE:-platform}}"
 suites_filter="${E2E_SUITES:-}"
 
-if ! command -v kubectl >/dev/null 2>&1; then
-  echo "ERROR: kubectl not found in PATH" >&2
-  exit 1
-fi
-
 if [ ! -d "$suites_dir" ]; then
   echo "ERROR: suites directory not found at $suites_dir" >&2
   exit 1
@@ -24,10 +19,6 @@ fi
 
 rm -rf "$artifacts_dir" "$diagnostics_root"
 mkdir -p "$artifacts_dir" "$diagnostics_root"
-
-if ! kubectl get namespace "$namespace" >/dev/null 2>&1; then
-  kubectl create namespace "$namespace"
-fi
 
 mapfile -t suite_files < <(find "$suites_dir" -mindepth 2 -maxdepth 2 -name suite.yaml | sort)
 
@@ -62,6 +53,69 @@ fi
 if [ "${#suite_files[@]}" -eq 0 ]; then
   echo "ERROR: No suites found under $suites_dir" >&2
   exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 not found in PATH" >&2
+  exit 1
+fi
+
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "ERROR: PyYAML is required for suite parsing. Install with: python3 -m pip install pyyaml" >&2
+  exit 1
+fi
+
+matched_suite_count=0
+selected_suite_files=()
+
+for suite_file in "${suite_files[@]}"; do
+  suite_dir=$(dirname "$suite_file")
+  suite_name=$(basename "$suite_dir")
+  tmp_dir=$(mktemp -d)
+
+  if ! python3 "$parse_script" "$suite_file" "$tmp_dir"; then
+    rm -rf "$tmp_dir"
+    echo "ERROR: failed to parse suite $suite_name" >&2
+    exit 1
+  fi
+
+  if ! select_output=$(
+    cd "$suite_dir"
+    export TAGS="$tags"
+    bash -s < "$tmp_dir/select"
+  ); then
+    rm -rf "$tmp_dir"
+    echo "ERROR: select failed for suite $suite_name" >&2
+    exit 1
+  fi
+
+  rm -rf "$tmp_dir"
+
+  if [ -n "$(echo "$select_output" | tr -d '[:space:]')" ]; then
+    selected_suite_files+=("$suite_file")
+    matched_suite_count=$((matched_suite_count + 1))
+  fi
+done
+
+if [ "$matched_suite_count" -eq 0 ] && [ -n "$(echo "$tags" | tr -d '[:space:]')" ]; then
+  echo "ERROR: TAGS matched zero suites: $tags" >&2
+  exit 1
+fi
+
+suite_files=("${selected_suite_files[@]}")
+
+if [ "${#suite_files[@]}" -eq 0 ]; then
+  echo "No suites selected."
+  exit 0
+fi
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "ERROR: kubectl not found in PATH" >&2
+  exit 1
+fi
+
+if ! kubectl get namespace "$namespace" >/dev/null 2>&1; then
+  kubectl create namespace "$namespace"
 fi
 
 overall_exit=0
@@ -102,6 +156,7 @@ for doc in docs:
 PY
     }
 
+    # shellcheck disable=SC2329
     cleanup() {
       local exit_code=$?
       set +e
@@ -171,20 +226,6 @@ PY
       exit 1
     fi
 
-    if ! select_output=$(
-      cd "$suite_dir"
-      export TAGS="$tags"
-      bash -s < "$select_file"
-    ); then
-      echo "ERROR: select failed for suite $suite_name" >&2
-      exit 1
-    fi
-
-    if [ -z "$(echo "$select_output" | tr -d '[:space:]')" ]; then
-      echo "Skipping suite $suite_name (no matching tests)."
-      exit 0
-    fi
-
     required_envs=()
     if [ -s "$required_env_file" ]; then
       while IFS= read -r env_name || [ -n "$env_name" ]; do
@@ -252,7 +293,7 @@ PY
 
     if [ -n "$service_account" ]; then
       service_account_ready=0
-      for attempt in $(seq 1 30); do
+      for _ in $(seq 1 30); do
         if kubectl get serviceaccount "$service_account" -n "$namespace" >/dev/null 2>&1; then
           service_account_ready=1
           break

--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -9,7 +9,7 @@ required_env:
   - CLAUDE_INIT_IMAGE
   - AGN_EXPOSE_INIT_IMAGE
 select: |
-  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "svc_organizations" "svc_files" "svc_gateway" "svc_media_proxy" "smoke")
+  suite_tags=("svc_agents_orchestrator" "svc_runners" "svc_metering" "svc_k8s_runner" "svc_organizations" "svc_files" "svc_gateway" "svc_media_proxy" "svc_llm" "svc_llm_proxy" "smoke")
 
   if [ -z "${TAGS:-}" ]; then
     echo "smoke"

--- a/suites/go-core/tests/diagnostics_helpers_test.go
+++ b/suites/go-core/tests/diagnostics_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_llm || svc_llm_proxy || smoke)
 
 package tests
 

--- a/suites/go-core/tests/gateway_helpers_test.go
+++ b/suites/go-core/tests/gateway_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_gateway || smoke)
+//go:build e2e && (svc_gateway || svc_llm || svc_llm_proxy || smoke)
 
 package tests
 

--- a/suites/go-core/tests/grpc.go
+++ b/suites/go-core/tests/grpc.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || svc_files || svc_gateway || svc_media_proxy || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || svc_files || svc_gateway || svc_media_proxy || svc_llm || svc_llm_proxy || smoke)
 
 package tests
 

--- a/suites/go-core/tests/llm_proxy_test.go
+++ b/suites/go-core/tests/llm_proxy_test.go
@@ -1,0 +1,127 @@
+//go:build e2e && (svc_llm || svc_llm_proxy)
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
+	llmv1connect "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1/llmv1connect"
+	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
+	usersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/users/v1"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	llmProxyURLDefault      = "http://llm-proxy:8080"
+	llmProxyRequestTimeout  = 45 * time.Second
+	llmProviderTestEndpoint = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+)
+
+func TestLLMProxyGatewayCreatedModel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	usersConn := dialGRPC(t, usersAddr)
+	orgsConn := dialGRPC(t, orgsAddr)
+	usersClient := usersv1.NewUsersServiceClient(usersConn)
+	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
+
+	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	apiToken := createAPIToken(t, ctx, usersClient, identityID)
+	organizationID := createTestOrganization(t, ctx, orgsClient, identityID)
+
+	llmClient := newLLMGatewayClient(t, apiToken)
+	providerID := createGatewayLLMProvider(t, ctx, llmClient, organizationID)
+	modelID := createGatewayLLMModel(t, ctx, llmClient, organizationID, providerID)
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), llmProxyRequestTimeout)
+		defer cleanupCancel()
+		_, _ = llmClient.DeleteModel(cleanupCtx, connect.NewRequest(&llmv1.DeleteModelRequest{Id: modelID}))
+		_, _ = llmClient.DeleteLLMProvider(cleanupCtx, connect.NewRequest(&llmv1.DeleteLLMProviderRequest{Id: providerID}))
+		_, _ = orgsClient.DeleteOrganization(withIdentity(cleanupCtx, identityID), &organizationsv1.DeleteOrganizationRequest{Id: organizationID})
+	})
+
+	requestBody := llmProxyResponsesRequest{Model: modelID, Input: "hi"}
+	responseBody, statusCode := postLLMProxyResponses(t, apiToken, requestBody)
+
+	require.NotEqual(t, http.StatusForbidden, statusCode, "llm-proxy unexpectedly rejected model access: %s", responseBody)
+	require.Equal(t, http.StatusOK, statusCode, "llm-proxy request failed: %s", responseBody)
+	require.Contains(t, responseBody, "Hi! How are you?")
+}
+
+func newLLMGatewayClient(t *testing.T, token string) llmv1connect.LLMServiceClient {
+	t.Helper()
+	return llmv1connect.NewLLMServiceClient(
+		newGatewayAuthenticatedClient(t, token),
+		gatewayBaseURL(t),
+	)
+}
+
+func createGatewayLLMProvider(t *testing.T, ctx context.Context, client llmv1connect.LLMServiceClient, organizationID string) string {
+	t.Helper()
+	resp, err := client.CreateLLMProvider(ctx, connect.NewRequest(&llmv1.CreateLLMProviderRequest{
+		Endpoint:       llmProviderTestEndpoint,
+		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_X_API_KEY,
+		Token:          "e2e-test-token",
+		OrganizationId: organizationID,
+		Protocol:       llmv1.Protocol_PROTOCOL_RESPONSES,
+	}))
+	require.NoError(t, err)
+	providerID := strings.TrimSpace(resp.Msg.GetProvider().GetMeta().GetId())
+	require.NotEmpty(t, providerID)
+	return providerID
+}
+
+func createGatewayLLMModel(t *testing.T, ctx context.Context, client llmv1connect.LLMServiceClient, organizationID string, providerID string) string {
+	t.Helper()
+	resp, err := client.CreateModel(ctx, connect.NewRequest(&llmv1.CreateModelRequest{
+		Name:           fmt.Sprintf("e2e-llm-proxy-%s", uuid.NewString()),
+		LlmProviderId:  providerID,
+		RemoteName:     "simple-hello",
+		OrganizationId: organizationID,
+	}))
+	require.NoError(t, err)
+	modelID := strings.TrimSpace(resp.Msg.GetModel().GetMeta().GetId())
+	require.NotEmpty(t, modelID)
+	return modelID
+}
+
+type llmProxyResponsesRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+func postLLMProxyResponses(t *testing.T, token string, payload llmProxyResponsesRequest) (string, int) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), llmProxyRequestTimeout)
+	defer cancel()
+
+	endpoint := strings.TrimRight(envOrDefault("LLM_PROXY_URL", llmProxyURLDefault), "/") + "/v1/responses"
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+token)
+
+	response, err := newGatewayClient(t).Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	return strings.TrimSpace(string(responseBody)), response.StatusCode
+}

--- a/suites/go-core/tests/llm_proxy_test.go
+++ b/suites/go-core/tests/llm_proxy_test.go
@@ -9,13 +9,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
-	"connectrpc.com/connect"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
-	llmv1connect "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1/llmv1connect"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	usersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/users/v1"
 	"github.com/google/uuid"
@@ -41,15 +39,20 @@ func TestLLMProxyGatewayCreatedModel(t *testing.T) {
 	apiToken := createAPIToken(t, ctx, usersClient, identityID)
 	organizationID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	llmClient := newLLMGatewayClient(t, apiToken)
-	providerID := createGatewayLLMProvider(t, ctx, llmClient, organizationID)
-	modelID := createGatewayLLMModel(t, ctx, llmClient, organizationID, providerID)
+	providerID, err := createGatewayLLMProvider(t, ctx, apiToken, organizationID)
+	if err != nil {
+		t.Fatalf("create llm provider through gateway: %v", err)
+	}
+	modelID, err := createGatewayLLMModel(t, ctx, apiToken, organizationID, providerID)
+	if err != nil {
+		t.Fatalf("create llm model through gateway: %v", err)
+	}
 
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), llmProxyRequestTimeout)
 		defer cleanupCancel()
-		_, _ = llmClient.DeleteModel(cleanupCtx, connect.NewRequest(&llmv1.DeleteModelRequest{Id: modelID}))
-		_, _ = llmClient.DeleteLLMProvider(cleanupCtx, connect.NewRequest(&llmv1.DeleteLLMProviderRequest{Id: providerID}))
+		postGatewayConnectBestEffort(t, cleanupCtx, apiToken, "DeleteModel", map[string]string{"id": modelID})
+		postGatewayConnectBestEffort(t, cleanupCtx, apiToken, "DeleteLLMProvider", map[string]string{"id": providerID})
 		_, _ = orgsClient.DeleteOrganization(withIdentity(cleanupCtx, identityID), &organizationsv1.DeleteOrganizationRequest{Id: organizationID})
 	})
 
@@ -61,41 +64,109 @@ func TestLLMProxyGatewayCreatedModel(t *testing.T) {
 	require.Contains(t, responseBody, "Hi! How are you?")
 }
 
-func newLLMGatewayClient(t *testing.T, token string) llmv1connect.LLMServiceClient {
+func createGatewayLLMProvider(t *testing.T, ctx context.Context, token string, organizationID string) (string, error) {
 	t.Helper()
-	return llmv1connect.NewLLMServiceClient(
-		newGatewayAuthenticatedClient(t, token),
-		gatewayBaseURL(t),
-	)
+	resp, err := postGatewayConnect[gatewayCreateLLMProviderResponse](t, ctx, token, "CreateLLMProvider", map[string]string{
+		"endpoint":       llmProviderTestEndpoint,
+		"authMethod":     "AUTH_METHOD_X_API_KEY",
+		"token":          "e2e-test-token",
+		"organizationId": organizationID,
+		"protocol":       "PROTOCOL_RESPONSES",
+	})
+	if err != nil {
+		return "", err
+	}
+	providerID := strings.TrimSpace(resp.Provider.Meta.ID)
+	if providerID == "" {
+		return "", fmt.Errorf("provider id missing")
+	}
+	return providerID, nil
 }
 
-func createGatewayLLMProvider(t *testing.T, ctx context.Context, client llmv1connect.LLMServiceClient, organizationID string) string {
+func createGatewayLLMModel(t *testing.T, ctx context.Context, token string, organizationID string, providerID string) (string, error) {
 	t.Helper()
-	resp, err := client.CreateLLMProvider(ctx, connect.NewRequest(&llmv1.CreateLLMProviderRequest{
-		Endpoint:       llmProviderTestEndpoint,
-		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_X_API_KEY,
-		Token:          "e2e-test-token",
-		OrganizationId: organizationID,
-		Protocol:       llmv1.Protocol_PROTOCOL_RESPONSES,
-	}))
-	require.NoError(t, err)
-	providerID := strings.TrimSpace(resp.Msg.GetProvider().GetMeta().GetId())
-	require.NotEmpty(t, providerID)
-	return providerID
+	resp, err := postGatewayConnect[gatewayCreateModelResponse](t, ctx, token, "CreateModel", map[string]string{
+		"name":           fmt.Sprintf("e2e-llm-proxy-%s", uuid.NewString()),
+		"llmProviderId":  providerID,
+		"remoteName":     "simple-hello",
+		"organizationId": organizationID,
+	})
+	if err != nil {
+		return "", err
+	}
+	modelID := strings.TrimSpace(resp.Model.Meta.ID)
+	if modelID == "" {
+		return "", fmt.Errorf("model id missing")
+	}
+	return modelID, nil
 }
 
-func createGatewayLLMModel(t *testing.T, ctx context.Context, client llmv1connect.LLMServiceClient, organizationID string, providerID string) string {
+type gatewayCreateLLMProviderResponse struct {
+	Provider gatewayLLMEntity `json:"provider"`
+}
+
+type gatewayCreateModelResponse struct {
+	Model gatewayLLMEntity `json:"model"`
+}
+
+type gatewayLLMEntity struct {
+	Meta gatewayEntityMeta `json:"meta"`
+}
+
+type gatewayEntityMeta struct {
+	ID string `json:"id"`
+}
+
+func postGatewayConnect[T any](t *testing.T, ctx context.Context, token string, method string, payload any) (T, error) {
 	t.Helper()
-	resp, err := client.CreateModel(ctx, connect.NewRequest(&llmv1.CreateModelRequest{
-		Name:           fmt.Sprintf("e2e-llm-proxy-%s", uuid.NewString()),
-		LlmProviderId:  providerID,
-		RemoteName:     "simple-hello",
-		OrganizationId: organizationID,
-	}))
-	require.NoError(t, err)
-	modelID := strings.TrimSpace(resp.Msg.GetModel().GetMeta().GetId())
-	require.NotEmpty(t, modelID)
-	return modelID
+	var response T
+	body, statusCode := postGatewayConnectRaw(t, ctx, token, method, payload)
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return response, fmt.Errorf("gateway %s failed with status %d: %s", method, statusCode, body)
+	}
+
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		return response, fmt.Errorf("decode gateway %s response: %w", method, err)
+	}
+	return response, nil
+}
+
+func postGatewayConnectBestEffort(t *testing.T, ctx context.Context, token string, method string, payload any) {
+	t.Helper()
+	_, _ = postGatewayConnectRaw(t, ctx, token, method, payload)
+}
+
+func postGatewayConnectRaw(t *testing.T, ctx context.Context, token string, method string, payload any) (string, int) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal gateway %s request: %v", method, err)
+	}
+
+	endpoint, err := url.JoinPath(gatewayBaseURL(t), "api/agynio.api.gateway.v1.LLMGateway", method)
+	if err != nil {
+		t.Fatalf("build gateway %s url: %v", method, err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build gateway %s request: %v", method, err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Connect-Protocol-Version", "1")
+	request.Header.Set("Authorization", "Bearer "+token)
+
+	response, err := newGatewayClient(t).Do(request)
+	if err != nil {
+		t.Fatalf("post gateway %s: %v", method, err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read gateway %s response: %v", method, err)
+	}
+	return strings.TrimSpace(string(responseBody)), response.StatusCode
 }
 
 type llmProxyResponsesRequest struct {
@@ -106,22 +177,30 @@ type llmProxyResponsesRequest struct {
 func postLLMProxyResponses(t *testing.T, token string, payload llmProxyResponsesRequest) (string, int) {
 	t.Helper()
 	body, err := json.Marshal(payload)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("marshal llm-proxy request: %v", err)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), llmProxyRequestTimeout)
 	defer cancel()
 
 	endpoint := strings.TrimRight(envOrDefault("LLM_PROXY_URL", llmProxyURLDefault), "/") + "/v1/responses"
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("build llm-proxy request: %v", err)
+	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Authorization", "Bearer "+token)
 
 	response, err := newGatewayClient(t).Do(request)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("post llm-proxy request: %v", err)
+	}
 	defer response.Body.Close()
 
 	responseBody, err := io.ReadAll(response.Body)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("read llm-proxy response: %v", err)
+	}
 	return strings.TrimSpace(string(responseBody)), response.StatusCode
 }

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || svc_llm || svc_llm_proxy || smoke)
 
 package tests
 

--- a/suites/go-core/tests/setup_test.go
+++ b/suites/go-core/tests/setup_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_agents_orchestrator || smoke)
+//go:build e2e && (svc_agents_orchestrator || svc_llm || svc_llm_proxy || smoke)
 
 package tests
 


### PR DESCRIPTION
## Summary

- Adds `svc_llm` and `svc_llm_proxy` selection tags to the go-core suite.
- Adds an E2E test that creates an LLM provider and model through the gateway, then calls `llm-proxy` with the created model and asserts non-403 success.
- Updates the E2E runner so tagged runs fail when no suites match the requested tags.

Closes #98

## Local validation

- `shellcheck scripts/run-pipeline.sh` — passed with no errors.
- `TAGS=definitely_no_suite ./scripts/run-pipeline.sh` — failed as expected with `ERROR: TAGS matched zero suites: definitely_no_suite`.
- `CGO_ENABLED=0 go test -run TestNonexistent -count=1 -tags "e2e svc_llm" ./tests/...` — passed: package `tests` ok with no tests to run; `tracecanary` no test files.
- `CGO_ENABLED=0 go test -run TestNonexistent -count=1 -tags "e2e svc_llm_proxy" ./tests/...` — passed: package `tests` ok with no tests to run; `tracecanary` no test files.

## Environment-limited checks

- `CGO_ENABLED=0 go test -count=1 -tags "e2e svc_llm" ./tests/...` reached the E2E test but could not connect to in-cluster services locally: `dial users:50051: context deadline exceeded`.
- `TAGS=svc_llm ./scripts/run-pipeline.sh` and `TAGS=svc_llm_proxy ./scripts/run-pipeline.sh` selected suites, then stopped at local Kubernetes RBAC: `system:serviceaccount:agyn-workloads:default` cannot create namespaces.