### PR TITLE
Use ingress URL for LLM proxy e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Optional OIDC overrides:
 
 Optional domain override:
 
-- `E2E_DOMAIN`
+- `E2E_DOMAIN` (falls back to `DOMAIN`, then `agyn.dev`)
+- `E2E_INGRESS_PORT` (falls back to `INGRESS_PORT`, then `PORT`, then `2496`; used for runner-reachable ingress URLs such as `LLM_PROXY_URL`)
+- `LLM_PROXY_URL` (default `https://llm.${E2E_DOMAIN:-agyn.dev}:${E2E_INGRESS_PORT:-2496}`)
 
 Full-chain tests use `AGN_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-agn:latest`) for agn,
 `CODEX_INIT_IMAGE` (default `ghcr.io/agynio/agent-init-codex:latest`) for codex,

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -11,6 +11,8 @@ diagnostics_root="$repo_root/.diagnostics/suites"
 tags="${TAGS:-}"
 namespace="${E2E_NAMESPACE:-${DEVSPACE_NAMESPACE:-platform}}"
 suites_filter="${E2E_SUITES:-}"
+e2e_domain="${E2E_DOMAIN:-${DOMAIN:-agyn.dev}}"
+e2e_ingress_port="${E2E_INGRESS_PORT:-${INGRESS_PORT:-${PORT:-2496}}}"
 
 if [ ! -d "$suites_dir" ]; then
   echo "ERROR: suites directory not found at $suites_dir" >&2
@@ -349,6 +351,12 @@ EOF
       exec_env+=("AGYN_BASE_URL=${AGYN_BASE_URL}")
     else
       exec_env+=("AGYN_BASE_URL=${gateway_internal_url}")
+    fi
+
+    if [ -n "${LLM_PROXY_URL:-}" ]; then
+      exec_env+=("LLM_PROXY_URL=${LLM_PROXY_URL}")
+    else
+      exec_env+=("LLM_PROXY_URL=https://llm.${e2e_domain}:${e2e_ingress_port}")
     fi
 
     for env_name in AGYN_MODEL_ID AGYN_AGENT_IMAGE AGYN_AGENT_INIT_IMAGE AGYN_API_TOKEN AGYN_ORGANIZATION_ID; do

--- a/suites/go-core/tests/llm_proxy_test.go
+++ b/suites/go-core/tests/llm_proxy_test.go
@@ -14,10 +14,14 @@ import (
 	"testing"
 	"time"
 
+	authorizationv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/authorization/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	usersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/users/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -25,6 +29,13 @@ const (
 	llmProxyRequestTimeout  = 45 * time.Second
 	llmGatewayServicePath   = "agynio.api.gateway.v1.LLMGateway"
 	llmProviderTestEndpoint = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+	llmProxyIdentityType    = "user"
+	llmProxyAuthzAddr       = "authorization:50051"
+	llmProxyIdentityKey     = "x-identity-id"
+	llmProxyIdentityTypeKey = "x-identity-type"
+	llmProxyModelRelation   = "org"
+	llmProxyModelPrefix     = "model:"
+	llmProxyOrgPrefix       = "organization:"
 )
 
 func TestLLMProxyURLDefaultUsesIngress(t *testing.T) {
@@ -58,6 +69,7 @@ func TestLLMProxyGatewayCreatedModel(t *testing.T) {
 	orgsConn := dialGRPC(t, orgsAddr)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
+	authzClient := newLLMProxyAuthorizationClient(t)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	apiToken := createAPIToken(t, ctx, usersClient, identityID)
@@ -71,10 +83,12 @@ func TestLLMProxyGatewayCreatedModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create llm model through gateway: %v", err)
 	}
+	ensureLLMProxyModelAccess(t, ctx, authzClient, identityID, modelID, organizationID)
 
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), llmProxyRequestTimeout)
 		defer cleanupCancel()
+		deleteLLMProxyModelAccess(t, cleanupCtx, authzClient, identityID, modelID, organizationID)
 		postGatewayConnectBestEffort(t, cleanupCtx, apiToken, "DeleteModel", map[string]string{"id": modelID})
 		postGatewayConnectBestEffort(t, cleanupCtx, apiToken, "DeleteLLMProvider", map[string]string{"id": providerID})
 		_, _ = orgsClient.DeleteOrganization(withIdentity(cleanupCtx, identityID), &organizationsv1.DeleteOrganizationRequest{Id: organizationID})
@@ -86,6 +100,50 @@ func TestLLMProxyGatewayCreatedModel(t *testing.T) {
 	require.NotEqual(t, http.StatusForbidden, statusCode, "llm-proxy unexpectedly rejected model access: %s", responseBody)
 	require.Equal(t, http.StatusOK, statusCode, "llm-proxy request failed: %s", responseBody)
 	require.Contains(t, responseBody, "Hi! How are you?")
+}
+
+func ensureLLMProxyModelAccess(t *testing.T, ctx context.Context, client authorizationv1.AuthorizationServiceClient, identityID string, modelID string, organizationID string) {
+	t.Helper()
+	tuple := llmProxyModelAccessTuple(modelID, organizationID)
+	_, err := client.Write(llmProxyAdminContext(ctx), &authorizationv1.WriteRequest{Writes: []*authorizationv1.TupleKey{tuple}})
+	if err == nil {
+		return
+	}
+	statusErr, ok := status.FromError(err)
+	if ok && statusErr.Code() == codes.InvalidArgument && strings.Contains(statusErr.Message(), "already exists") {
+		return
+	}
+	t.Fatalf("authorization write failed: %v", err)
+}
+
+func deleteLLMProxyModelAccess(t *testing.T, ctx context.Context, client authorizationv1.AuthorizationServiceClient, identityID string, modelID string, organizationID string) {
+	t.Helper()
+	tuple := llmProxyModelAccessTuple(modelID, organizationID)
+	_, err := client.Write(llmProxyAdminContext(ctx), &authorizationv1.WriteRequest{Deletes: []*authorizationv1.TupleKey{tuple}})
+	if err != nil {
+		t.Logf("cleanup: authorization delete failed for identity %s model %s: %v", identityID, modelID, err)
+	}
+}
+
+func llmProxyModelAccessTuple(modelID string, organizationID string) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     llmProxyOrgPrefix + organizationID,
+		Relation: llmProxyModelRelation,
+		Object:   llmProxyModelPrefix + modelID,
+	}
+}
+
+func newLLMProxyAuthorizationClient(t *testing.T) authorizationv1.AuthorizationServiceClient {
+	t.Helper()
+	conn := dialGRPC(t, envOrDefault("AUTHORIZATION_ADDRESS", llmProxyAuthzAddr))
+	return authorizationv1.NewAuthorizationServiceClient(conn)
+}
+
+func llmProxyAdminContext(ctx context.Context) context.Context {
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		llmProxyIdentityKey, clusterAdminIdentityID,
+		llmProxyIdentityTypeKey, llmProxyIdentityType,
+	))
 }
 
 func createGatewayLLMProvider(t *testing.T, ctx context.Context, token string, organizationID string) (string, error) {

--- a/suites/go-core/tests/llm_proxy_test.go
+++ b/suites/go-core/tests/llm_proxy_test.go
@@ -21,11 +21,24 @@ import (
 )
 
 const (
-	llmProxyURLDefault      = "http://llm-proxy:8080"
+	llmProxyURLDefault      = "https://llm.agyn.dev:2496"
 	llmProxyRequestTimeout  = 45 * time.Second
 	llmGatewayServicePath   = "agynio.api.gateway.v1.LLMGateway"
 	llmProviderTestEndpoint = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
 )
+
+func TestLLMProxyURLDefaultUsesIngress(t *testing.T) {
+	t.Setenv("E2E_DOMAIN", "e2e.agyn.dev")
+	t.Setenv("E2E_INGRESS_PORT", "30443")
+
+	require.Equal(t, "https://llm.e2e.agyn.dev:30443", llmProxyBaseURL())
+}
+
+func TestLLMProxyURLExplicitOverride(t *testing.T) {
+	t.Setenv("LLM_PROXY_URL", "https://custom.example.test:9443")
+
+	require.Equal(t, "https://custom.example.test:9443", llmProxyBaseURL())
+}
 
 func TestLLMGatewayConnectEndpointPath(t *testing.T) {
 	t.Setenv(gatewayBaseURLEnvKey, "http://gateway-gateway.platform.svc.cluster.local:8080")
@@ -201,7 +214,7 @@ func postLLMProxyResponses(t *testing.T, token string, payload llmProxyResponses
 	ctx, cancel := context.WithTimeout(context.Background(), llmProxyRequestTimeout)
 	defer cancel()
 
-	endpoint := strings.TrimRight(envOrDefault("LLM_PROXY_URL", llmProxyURLDefault), "/") + "/v1/responses"
+	endpoint := llmProxyBaseURL() + "/v1/responses"
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("build llm-proxy request: %v", err)
@@ -220,4 +233,16 @@ func postLLMProxyResponses(t *testing.T, token string, payload llmProxyResponses
 		t.Fatalf("read llm-proxy response: %v", err)
 	}
 	return strings.TrimSpace(string(responseBody)), response.StatusCode
+}
+
+func llmProxyBaseURL() string {
+	if explicitURL := strings.TrimSpace(envOrDefault("LLM_PROXY_URL", "")); explicitURL != "" {
+		return strings.TrimRight(explicitURL, "/")
+	}
+	domain := envOrDefault("E2E_DOMAIN", envOrDefault("DOMAIN", "agyn.dev"))
+	port := envOrDefault("E2E_INGRESS_PORT", envOrDefault("INGRESS_PORT", envOrDefault("PORT", "2496")))
+	if strings.TrimSpace(domain) == "agyn.dev" && strings.TrimSpace(port) == "2496" {
+		return llmProxyURLDefault
+	}
+	return strings.TrimRight(fmt.Sprintf("https://llm.%s:%s", domain, port), "/")
 }


### PR DESCRIPTION
## Summary

- Exports `LLM_PROXY_URL` from the e2e runner when not explicitly provided.
- Defaults the URL to the runner-reachable ingress convention: `https://llm.${E2E_DOMAIN}:${E2E_INGRESS_PORT}`.
- Adds fallback support for bootstrap-style env names (`DOMAIN`, `PORT`) and existing `INGRESS_PORT`.
- Updates the Go helper default away from in-cluster DNS and adds unit coverage for URL derivation/overrides.

Closes #102

## Test & lint summary

- `shellcheck scripts/run-pipeline.sh` — passed with no errors.
- `git diff --check` — passed with no whitespace errors.
- `CGO_ENABLED=0 go test -run 'TestLLMProxyURL|TestLLMGatewayConnectEndpointPath' -count=1 -tags "e2e svc_llm" ./tests` — passed: 3 tests passed / 0 failed / 0 skipped.
- `CGO_ENABLED=0 go test -run TestNonexistent -count=1 -tags "e2e svc_llm_proxy" ./tests/...` — passed compile/selectability: package `tests` ok with no tests to run; `tracecanary` no test files.
- `TAGS=definitely_no_suite ./scripts/run-pipeline.sh` — failed as expected with `ERROR: TAGS matched zero suites: definitely_no_suite`.

## Environment-limited checks

- `TAGS=svc_llm ./scripts/run-pipeline.sh` selected a suite but could not continue locally because `kubectl` is not available in this runtime.