### PR TITLE
test: set agent availability in e2e

### DIFF
--- a/suites/go-core/tests/agent_agyn_wait_test.go
+++ b/suites/go-core/tests/agent_agyn_wait_test.go
@@ -62,12 +62,12 @@ func TestAgentAgynCLIWaitToAnotherAgent(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentBID) })
 
-	agentA := createAgent(t, ctx, agentsClient, "e2e-agyn-wait-agent-a-"+uuid.NewString(), agentAModel.GetMeta().GetId(), orgID, agnInitImage)
+	agentA := createAgent(t, threadsCtx, agentsClient, "e2e-agyn-wait-agent-a-"+uuid.NewString(), agentAModel.GetMeta().GetId(), orgID, agnInitImage)
 	agentAID := agentA.GetMeta().GetId()
 	if agentAID == "" {
 		t.Fatal("create agent A: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentAID) })
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentAID) })
 
 	threadA := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentAID})
 	threadAID := threadA.GetId()

--- a/suites/go-core/tests/dedup_test.go
+++ b/suites/go-core/tests/dedup_test.go
@@ -51,13 +51,13 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-nodup-%s", uuid.NewString()), modelID, orgID, codexInitImage)
+	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-test-agent-nodup-%s", uuid.NewString()), modelID, orgID, codexInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -192,15 +192,15 @@ func setupExposeTestWorkload(t *testing.T) exposeWorkloadFixture {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-expose-%s", uuid.NewString()), modelID, orgID, exposeInitImage)
+	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-expose-%s", uuid.NewString()), modelID, orgID, exposeInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
-	createAgentEnv(t, ctx, agentsClient, agentID, "HOME", "/tmp")
-	createAgentEnv(t, ctx, agentsClient, agentID, "AGYN_GATEWAY_URL", "http://gateway:8080")
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "HOME", "/tmp")
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "AGYN_GATEWAY_URL", "http://gateway:8080")
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()

--- a/suites/go-core/tests/gateway_agents_test.go
+++ b/suites/go-core/tests/gateway_agents_test.go
@@ -44,6 +44,7 @@ func TestAgentsGateway_CreateAndDeleteAgent(t *testing.T) {
 		Image:          gatewayAgentImage(t),
 		InitImage:      gatewayAgentInitImage(t),
 		OrganizationId: gatewayOrganizationID(t),
+		Availability:   agentsv1.AgentAvailability_AGENT_AVAILABILITY_INTERNAL,
 	}
 	createResp, err := client.CreateAgent(ctx, connect.NewRequest(createReq))
 	require.NoError(t, err)
@@ -108,6 +109,7 @@ func createGatewayAgent(t *testing.T, client gatewayv1connect.AgentsGatewayClien
 		Image:          gatewayAgentImage(t),
 		InitImage:      gatewayAgentInitImage(t),
 		OrganizationId: gatewayOrganizationID(t),
+		Availability:   agentsv1.AgentAvailability_AGENT_AVAILABILITY_INTERNAL,
 	}))
 	require.NoError(t, err)
 	require.NotNil(t, resp)

--- a/suites/go-core/tests/idle_test.go
+++ b/suites/go-core/tests/idle_test.go
@@ -61,13 +61,13 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	}
 
 	idleTimeout := "15s"
-	agent := createAgentWithIdleTimeout(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-idle-%s", uuid.NewString()), modelID, orgID, codexInitImage, idleTimeout)
+	agent := createAgentWithIdleTimeout(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-test-agent-idle-%s", uuid.NewString()), modelID, orgID, codexInitImage, idleTimeout)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
 	agentThreadsCtx := withIdentity(ctx, agentID)
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
 	agentInfoResp, err := agentsClient.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
 	if err != nil {
 		t.Fatalf("get agent %s: %v", agentID, err)
@@ -81,7 +81,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	} else {
 		t.Logf("diagnostics: agent idle_timeout=%q", agentInfo.GetIdleTimeout())
 	}
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()

--- a/suites/go-core/tests/imagepull_test.go
+++ b/suites/go-core/tests/imagepull_test.go
@@ -80,13 +80,13 @@ func TestImagePullSecretAttachedToPod(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteImagePullSecret(t, ctx, secretsClient, imagePullSecretID) })
 
-	agent := createAgent(t, ctx, agentsClient, "e2e-image-pull-"+uuid.NewString(), modelID, orgID, codexInitImage)
+	agent := createAgent(t, threadsCtx, agentsClient, "e2e-image-pull-"+uuid.NewString(), modelID, orgID, codexInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	attachment := createImagePullSecretAttachment(t, ctx, agentsClient, imagePullSecretID, agentID)
 	attachmentID := attachment.GetMeta().GetId()

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -196,6 +196,7 @@ func createAgentWithOptions(t *testing.T, ctx context.Context, client agentsv1.A
 		Image:          "alpine:3.21",
 		InitImage:      opts.InitImage,
 		OrganizationId: opts.OrganizationID,
+		Availability:   agentsv1.AgentAvailability_AGENT_AVAILABILITY_INTERNAL,
 	}
 	if opts.IdleTimeout != "" {
 		request.IdleTimeout = &opts.IdleTimeout

--- a/suites/go-core/tests/mcp_test.go
+++ b/suites/go-core/tests/mcp_test.go
@@ -60,13 +60,13 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, "e2e-mcp-tools-"+uuid.NewString(), modelID, orgID, initImage)
+	agent := createAgent(t, threadsCtx, agentsClient, "e2e-mcp-tools-"+uuid.NewString(), modelID, orgID, initImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 	memoryMCP := createMCP(
 		t,
 		ctx,

--- a/suites/go-core/tests/multi_test.go
+++ b/suites/go-core/tests/multi_test.go
@@ -51,17 +51,17 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	agentA := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-a-%s", uuid.NewString()), modelID, orgID, codexInitImage)
-	agentB := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-b-%s", uuid.NewString()), modelID, orgID, codexInitImage)
+	agentA := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-a-%s", uuid.NewString()), modelID, orgID, codexInitImage)
+	agentB := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-b-%s", uuid.NewString()), modelID, orgID, codexInitImage)
 	agentAID := agentA.GetMeta().GetId()
 	agentBID := agentB.GetMeta().GetId()
 	if agentAID == "" || agentBID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentAID) })
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentBID) })
-	createAgentEnv(t, ctx, agentsClient, agentAID, "LLM_API_TOKEN", token)
-	createAgentEnv(t, ctx, agentsClient, agentBID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentAID) })
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentBID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentAID, "LLM_API_TOKEN", token)
+	createAgentEnv(t, threadsCtx, agentsClient, agentBID, "LLM_API_TOKEN", token)
 
 	threadA := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentAID})
 	threadB := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentBID})
@@ -186,13 +186,13 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-thread-%s", uuid.NewString()), modelID, orgID, codexInitImage)
+	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-thread-%s", uuid.NewString()), modelID, orgID, codexInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	threadA := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadB := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})

--- a/suites/go-core/tests/pipeline_test.go
+++ b/suites/go-core/tests/pipeline_test.go
@@ -70,13 +70,13 @@ func runFullPipelineMessageResponseWithProtocol(t *testing.T, llmEndpoint, initI
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-pipeline-%s", uuid.NewString()), modelID, orgID, initImage)
+	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-pipeline-%s", uuid.NewString()), modelID, orgID, initImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()

--- a/suites/go-core/tests/start_test.go
+++ b/suites/go-core/tests/start_test.go
@@ -51,13 +51,13 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-start-%s", uuid.NewString()), modelID, orgID, codexInitImage)
+	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-test-agent-start-%s", uuid.NewString()), modelID, orgID, codexInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()

--- a/suites/go-core/tests/threads_send_test.go
+++ b/suites/go-core/tests/threads_send_test.go
@@ -52,13 +52,13 @@ func TestThreadsSendShell(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-threads-send-%s", uuid.NewString()), modelID, orgID, agnInitImage)
+	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-threads-send-%s", uuid.NewString()), modelID, orgID, agnInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()

--- a/suites/go-core/tests/workload_start_retry_policy_test.go
+++ b/suites/go-core/tests/workload_start_retry_policy_test.go
@@ -22,14 +22,14 @@ import (
 )
 
 const (
-	startRetryTestTimeout  = 8 * time.Minute
-	failedWorkloadTimeout  = 3 * time.Minute
-	fastRetryTimeout       = 40 * time.Second
-	fastRetryWindow        = 30 * time.Second
-	responseWaitTimeout    = 3 * time.Minute
-	runnerCleanupTimeout   = 90 * time.Second
-	invalidInitImage       = "INVALID_IMAGE_NAME:latest"
-	expectedAgentResponse  = "Hi! How are you?"
+	startRetryTestTimeout = 8 * time.Minute
+	failedWorkloadTimeout = 3 * time.Minute
+	fastRetryTimeout      = 40 * time.Second
+	fastRetryWindow       = 30 * time.Second
+	responseWaitTimeout   = 3 * time.Minute
+	runnerCleanupTimeout  = 90 * time.Second
+	invalidInitImage      = "INVALID_IMAGE_NAME:latest"
+	expectedAgentResponse = "Hi! How are you?"
 )
 
 var configInvalidContainerReasons = map[string]struct{}{
@@ -74,13 +74,13 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-start-retry-%s", uuid.NewString()), modelID, orgID, invalidInitImage)
+	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-start-retry-%s", uuid.NewString()), modelID, orgID, invalidInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
-	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
+	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()

--- a/suites/playwright-tracing-app/test/e2e/gateway-api.ts
+++ b/suites/playwright-tracing-app/test/e2e/gateway-api.ts
@@ -262,6 +262,7 @@ export async function createAgent(page: Page, params: {
     model: params.model,
     image: params.image,
     initImage,
+    availability: 'AGENT_AVAILABILITY_INTERNAL',
     role: params.role ?? 'assistant',
   };
   if (params.description !== undefined) {


### PR DESCRIPTION
## Summary
- Sets `AGENT_AVAILABILITY_INTERNAL` when centralized E2E helpers create agents.
- Keeps go-core and Playwright gateway helpers aligned with required CreateAgent availability validation.

## Validation
- `git diff --check`
- `go test -run '^$' -tags 'e2e svc_agents_orchestrator' ./tests/...`

Related to agynio/agents#54.