### PR TITLE
Fix chat-app CreateAgent availability format

### DIFF
--- a/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { AgentAvailability } from '../../src/gen/agynio/api/agents/v1/agents_pb';
+import { buildCreateAgentPayload } from './chat-api';
+
+test.describe('chat api helpers', () => {
+  test('CreateAgent payload includes internal availability', () => {
+    const payload = buildCreateAgentPayload({
+      organizationId: 'organization-id',
+      name: 'agent-name',
+      role: 'assistant',
+      model: 'model-id',
+      description: 'description',
+      configuration: '{}',
+      image: 'alpine:3.21',
+      initImage: 'ghcr.io/agynio/agent-init-codex:latest',
+    });
+
+    expect(payload.availability).toBe(AgentAvailability.INTERNAL);
+    expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
+      availability: AgentAvailability.INTERNAL,
+    });
+  });
+});

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -1,6 +1,6 @@
-import { create, enumToJson, toJson } from '@bufbuild/protobuf';
+import { enumToJson } from '@bufbuild/protobuf';
 import type { Page } from '@playwright/test';
-import { AgentAvailability, AgentAvailabilitySchema, CreateAgentRequestSchema } from '../../src/gen/agynio/api/agents/v1/agents_pb';
+import { AgentAvailability } from '../../src/gen/agynio/api/agents/v1/agents_pb';
 import { ChatStatus, ChatStatusSchema } from '../../src/gen/agynio/api/chat/v1/chat_pb';
 import { MembershipRole, MembershipRoleSchema } from '../../src/gen/agynio/api/organizations/v1/organizations_pb';
 
@@ -399,6 +399,10 @@ type CreateAgentOptions = {
   availability?: AgentAvailability;
 };
 
+type CreateAgentPayload = Omit<CreateAgentOptions, 'availability'> & {
+  availability: AgentAvailability;
+};
+
 type SetupTestAgentOptions = {
   endpoint: string;
   initImage?: string;
@@ -437,12 +441,7 @@ export async function createAgent(page: Page, opts: CreateAgentOptions): Promise
   if (!trimmedInitImage) {
     throw new Error('initImage is required to create chat agents.');
   }
-  const request = create(CreateAgentRequestSchema, {
-    ...rest,
-    initImage: trimmedInitImage,
-    availability: opts.availability ?? AgentAvailability.INTERNAL,
-  });
-  const payload = toJson(CreateAgentRequestSchema, request);
+  const payload = buildCreateAgentPayload({ ...rest, initImage: trimmedInitImage });
   const response = await postConnect<CreateAgentResponseWire>(
     page,
     AGENTS_GATEWAY_PATH,
@@ -455,6 +454,14 @@ export async function createAgent(page: Page, opts: CreateAgentOptions): Promise
   const agentId = response.agent.meta.id;
   await waitForAgent(page, opts.organizationId, agentId);
   return agentId;
+}
+
+export function buildCreateAgentPayload(opts: CreateAgentOptions): CreateAgentPayload {
+  const { availability = AgentAvailability.INTERNAL, ...rest } = opts;
+  return {
+    ...rest,
+    availability,
+  };
 }
 
 export async function createTestModel(


### PR DESCRIPTION
## Summary
- Fixes #110
- Updates the exact `playwright-chat-app` CreateAgent helper used by `setupTestAgent` in the failing stack from chat-app run `26102219676`.
- Sends `availability` as the generated numeric `AgentAvailability.INTERNAL` value instead of the enum-name JSON string.
- Adds a focused Playwright helper spec asserting the CreateAgent payload keeps `availability: AgentAvailability.INTERNAL` when serialized.

## Investigation
The failing run used e2e checkout `d0461bf1ff57ef3956ea903ec82c7bb7843bc3bc` and failed at:

`/opt/app/data/test/e2e/chat-api.ts:183 -> createAgent:439 -> setupTestAgent:497`

That points to `suites/playwright-chat-app/test/e2e/chat-api.ts`, not another helper. The previous PR added the enum JSON name (`AGENT_AVAILABILITY_INTERNAL`); this follow-up uses the generated numeric enum value (`1`) so the Go Connect gateway decodes it as `AGENT_AVAILABILITY_INTERNAL` before forwarding to agents.

## Validation
- `npm ci --no-fund --no-audit` — completed successfully
- `npx buf generate` — completed successfully
- `npx tsc --noEmit` — completed successfully
- `E2E_BASE_URL=https://chat.agyn.dev npx playwright test test/e2e/chat-api.spec.ts --pass-with-no-tests` — 1 passed / 0 failed / 0 skipped