### PR TITLE
fix(chat-app): serialize availability enum name

### DIFF
--- a/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
@@ -3,7 +3,7 @@ import { AgentAvailability } from '../../src/gen/agynio/api/agents/v1/agents_pb'
 import { buildCreateAgentPayload } from './chat-api';
 
 test.describe('chat api helpers', () => {
-  test('CreateAgent payload includes internal availability', () => {
+  test('CreateAgent payload serializes availability as ConnectRPC enum name', () => {
     const payload = buildCreateAgentPayload({
       organizationId: 'organization-id',
       name: 'agent-name',
@@ -15,9 +15,34 @@ test.describe('chat api helpers', () => {
       initImage: 'ghcr.io/agynio/agent-init-codex:latest',
     });
 
-    expect(payload.availability).toBe(AgentAvailability.INTERNAL);
+    expect(JSON.parse(JSON.stringify(payload))).toEqual({
+      organizationId: 'organization-id',
+      name: 'agent-name',
+      role: 'assistant',
+      model: 'model-id',
+      description: 'description',
+      configuration: '{}',
+      image: 'alpine:3.21',
+      initImage: 'ghcr.io/agynio/agent-init-codex:latest',
+      availability: 'AGENT_AVAILABILITY_INTERNAL',
+    });
+  });
+
+  test('CreateAgent payload serializes private availability as ConnectRPC enum name', () => {
+    const payload = buildCreateAgentPayload({
+      organizationId: 'organization-id',
+      name: 'agent-name',
+      role: 'assistant',
+      model: 'model-id',
+      description: 'description',
+      configuration: '{}',
+      image: 'alpine:3.21',
+      initImage: 'ghcr.io/agynio/agent-init-codex:latest',
+      availability: AgentAvailability.PRIVATE,
+    });
+
     expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
-      availability: AgentAvailability.INTERNAL,
+      availability: 'AGENT_AVAILABILITY_PRIVATE',
     });
   });
 });

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -1,6 +1,9 @@
 import { enumToJson } from '@bufbuild/protobuf';
 import type { Page } from '@playwright/test';
-import { AgentAvailability } from '../../src/gen/agynio/api/agents/v1/agents_pb';
+import {
+  AgentAvailability,
+  AgentAvailabilitySchema,
+} from '../../src/gen/agynio/api/agents/v1/agents_pb';
 import { ChatStatus, ChatStatusSchema } from '../../src/gen/agynio/api/chat/v1/chat_pb';
 import { MembershipRole, MembershipRoleSchema } from '../../src/gen/agynio/api/organizations/v1/organizations_pb';
 
@@ -127,6 +130,11 @@ const MEMBERSHIP_ROLE_MAP = {
   MEMBERSHIP_ROLE_OWNER: enumName(MembershipRoleSchema, MembershipRole.OWNER),
   MEMBERSHIP_ROLE_MEMBER: enumName(MembershipRoleSchema, MembershipRole.MEMBER),
 } satisfies Record<MembershipRoleValue, string>;
+
+const AGENT_AVAILABILITY_MAP = {
+  [AgentAvailability.INTERNAL]: enumName(AgentAvailabilitySchema, AgentAvailability.INTERNAL),
+  [AgentAvailability.PRIVATE]: enumName(AgentAvailabilitySchema, AgentAvailability.PRIVATE),
+} satisfies Record<AgentAvailability.INTERNAL | AgentAvailability.PRIVATE, string>;
 
 function resolveBaseUrl(): string {
   const baseUrl = process.env.E2E_BASE_URL;
@@ -400,7 +408,7 @@ type CreateAgentOptions = {
 };
 
 type CreateAgentPayload = Omit<CreateAgentOptions, 'availability'> & {
-  availability: AgentAvailability;
+  availability: string;
 };
 
 type SetupTestAgentOptions = {
@@ -458,9 +466,12 @@ export async function createAgent(page: Page, opts: CreateAgentOptions): Promise
 
 export function buildCreateAgentPayload(opts: CreateAgentOptions): CreateAgentPayload {
   const { availability = AgentAvailability.INTERNAL, ...rest } = opts;
+  if (availability !== AgentAvailability.INTERNAL && availability !== AgentAvailability.PRIVATE) {
+    throw new Error(`Unsupported agent availability: ${availability}`);
+  }
   return {
     ...rest,
-    availability,
+    availability: AGENT_AVAILABILITY_MAP[availability],
   };
 }
 


### PR DESCRIPTION
## Summary
- Fixes chat app CreateAgent JSON payload to send `availability` as the protobuf enum name expected by ConnectRPC JSON.
- Adds payload serialization coverage for default internal and explicit private availability.

## Evidence
- Current `main` at merge commit `4341328` sent raw numeric JSON: `{ "availability": 1 }`.
- `@bufbuild/protobuf` `enumToJson(AgentAvailabilitySchema, AgentAvailability.INTERNAL)` returns `AGENT_AVAILABILITY_INTERNAL`.
- Connect unary JSON requests use protobuf JSON bodies, and ProtoJSON emits enum names as strings by default.
- Updated serialized payload assertion expects: `{ "availability": "AGENT_AVAILABILITY_INTERNAL" }`.

## Validation
- `E2E_BASE_URL=http://127.0.0.1 npx tsc --noEmit`
- `E2E_BASE_URL=http://127.0.0.1 npx playwright test test/e2e/chat-api.spec.ts --reporter=list`

Closes #110