### PR TITLE
fix(chat-app): omit default internal availability

### DIFF
--- a/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
@@ -3,7 +3,7 @@ import { AgentAvailability } from '../../src/gen/agynio/api/agents/v1/agents_pb'
 import { buildCreateAgentPayload } from './chat-api';
 
 test.describe('chat api helpers', () => {
-  test('CreateAgent payload serializes availability as backend value', () => {
+  test('CreateAgent payload omits default internal availability', () => {
     const payload = buildCreateAgentPayload({
       organizationId: 'organization-id',
       name: 'agent-name',
@@ -24,11 +24,10 @@ test.describe('chat api helpers', () => {
       configuration: '{}',
       image: 'alpine:3.21',
       initImage: 'ghcr.io/agynio/agent-init-codex:latest',
-      availability: 'internal',
     });
   });
 
-  test('CreateAgent payload serializes private availability as backend value', () => {
+  test('CreateAgent payload serializes private availability as enum number', () => {
     const payload = buildCreateAgentPayload({
       organizationId: 'organization-id',
       name: 'agent-name',
@@ -42,7 +41,7 @@ test.describe('chat api helpers', () => {
     });
 
     expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
-      availability: 'private',
+      availability: AgentAvailability.PRIVATE,
     });
   });
 });

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -28,11 +28,6 @@ const MEMBERSHIP_ROLE_MAP = {
   MEMBERSHIP_ROLE_MEMBER: 'MEMBERSHIP_ROLE_MEMBER',
 } satisfies Record<MembershipRoleValue, string>;
 
-const AGENT_AVAILABILITY_MAP = {
-  [AgentAvailability.INTERNAL]: 'internal',
-  [AgentAvailability.PRIVATE]: 'private',
-} satisfies Record<AgentAvailability.INTERNAL | AgentAvailability.PRIVATE, string>;
-
 const DEBUG_CREATE_AGENT_PAYLOAD = process.env.E2E_DEBUG_CREATE_AGENT_PAYLOAD === 'true';
 const REDACTED_VALUE = '<redacted>';
 const SENSITIVE_KEY_PATTERN = /token|secret|password|authorization|credential/i;
@@ -420,7 +415,7 @@ type CreateAgentOptions = {
 };
 
 type CreateAgentPayload = Omit<CreateAgentOptions, 'availability'> & {
-  availability: string;
+  availability?: number;
 };
 
 type SetupTestAgentOptions = {
@@ -484,10 +479,10 @@ export function buildCreateAgentPayload(opts: CreateAgentOptions): CreateAgentPa
   if (availability !== AgentAvailability.INTERNAL && availability !== AgentAvailability.PRIVATE) {
     throw new Error(`Unsupported agent availability: ${availability}`);
   }
-  return {
-    ...rest,
-    availability: AGENT_AVAILABILITY_MAP[availability],
-  };
+  if (availability === AgentAvailability.INTERNAL) {
+    return rest;
+  }
+  return { ...rest, availability };
 }
 
 export async function createTestModel(


### PR DESCRIPTION
## Summary
- Omits `availability` from chat-app CreateAgent requests when using the default internal availability.
- Leaves support for explicit private availability as the generated enum number.
- Updates unit coverage for the exact serialized payload.

## Investigation evidence
- chat-app CI run `26111810664` checked out e2e commit `f76539e`.
- It hit `https://chat.agyn.dev/api/agynio.api.gateway.v1.AgentsGateway/CreateAgent`, which maps to `gateway.v1.AgentsGateway.CreateAgent` and forwards `agents.v1.CreateAgentRequest` to `AgentsService.CreateAgent`.
- Gateway proto maps `CreateAgent` directly to `agynio.api.agents.v1.CreateAgentRequest`; that request field is enum `AgentAvailability availability = 13`.
- Agents service accepts only proto enum values `AGENT_AVAILABILITY_INTERNAL` / `AGENT_AVAILABILITY_PRIVATE`; its 400 response body was: `{ "code":"invalid_argument", "message":"availability: must be internal or private" }`.
- Captured failing payload included: `"availability":"internal"` with `initImage":"ghcr.io/agynio/agent-init-codex:latest"`.
- Since numeric `1`, enum name `AGENT_AVAILABILITY_INTERNAL`, and string `internal` all produced zero/invalid availability through this path, the safe default path is to omit `availability` and rely on backend/default internal behavior.

## Validation
- `E2E_BASE_URL=http://127.0.0.1 npx tsc --noEmit`
- `E2E_BASE_URL=http://127.0.0.1 npx playwright test test/e2e/chat-api.spec.ts --reporter=list`

Related to #110