### PR TITLE
fix(console): set agent availability

### DIFF
--- a/suites/playwright/test/e2e/console-api.spec.ts
+++ b/suites/playwright/test/e2e/console-api.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { buildCreateAgentPayload } from './console-api';
+
+test.describe('console api helpers', () => {
+  test('CreateAgent payload defaults availability to internal', () => {
+    const payload = buildCreateAgentPayload(
+      {
+        organizationId: 'organization-id',
+        name: 'agent-name',
+      },
+      'model-id',
+    );
+
+    expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
+      availability: 'AGENT_AVAILABILITY_INTERNAL',
+    });
+  });
+
+  test('CreateAgent payload keeps caller availability override', () => {
+    const payload = buildCreateAgentPayload(
+      {
+        organizationId: 'organization-id',
+        name: 'agent-name',
+        availability: 'AGENT_AVAILABILITY_PRIVATE',
+      },
+      'model-id',
+    );
+
+    expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
+      availability: 'AGENT_AVAILABILITY_PRIVATE',
+    });
+  });
+});

--- a/suites/playwright/test/e2e/console-api.ts
+++ b/suites/playwright/test/e2e/console-api.ts
@@ -287,6 +287,35 @@ type MembershipStatusValue =
   | 'MEMBERSHIP_STATUS_UNSPECIFIED'
   | 'MEMBERSHIP_STATUS_PENDING'
   | 'MEMBERSHIP_STATUS_ACTIVE';
+type AgentAvailabilityValue = 'AGENT_AVAILABILITY_INTERNAL' | 'AGENT_AVAILABILITY_PRIVATE';
+
+const DEFAULT_AGENT_AVAILABILITY: AgentAvailabilityValue = 'AGENT_AVAILABILITY_INTERNAL';
+
+type CreateAgentOptions = {
+  organizationId: string;
+  name: string;
+  nickname?: string;
+  role?: string;
+  model?: string;
+  description?: string;
+  configuration?: string;
+  image?: string;
+  initImage?: string;
+  availability?: AgentAvailabilityValue;
+};
+
+type CreateAgentPayload = {
+  name: string;
+  nickname?: string;
+  role: string;
+  model: string;
+  description: string;
+  configuration: string;
+  image: string;
+  initImage: string;
+  organizationId: string;
+  availability: AgentAvailabilityValue;
+};
 
 function resolveBaseUrl(): string {
   const baseUrl = process.env.E2E_BASE_URL;
@@ -856,35 +885,8 @@ export async function createImagePullSecret(
   return secretId;
 }
 
-export async function createAgent(
-  page: Page,
-  opts: {
-    organizationId: string;
-    name: string;
-    nickname?: string;
-    role?: string;
-    model?: string;
-    description?: string;
-    configuration?: string;
-    image?: string;
-    initImage?: string;
-  },
-): Promise<string> {
-  let modelId = opts.model?.trim() ?? '';
-  if (!modelId) {
-    modelId = await ensureModelId(page, opts.organizationId);
-  }
-  const payload: {
-    name: string;
-    nickname?: string;
-    role: string;
-    model: string;
-    description: string;
-    configuration: string;
-    image: string;
-    initImage: string;
-    organizationId: string;
-  } = {
+export function buildCreateAgentPayload(opts: CreateAgentOptions, modelId: string): CreateAgentPayload {
+  return {
     name: opts.name,
     role: opts.role ?? 'assistant',
     model: modelId,
@@ -893,7 +895,16 @@ export async function createAgent(
     image: opts.image ?? '',
     initImage: opts.initImage ?? '',
     organizationId: opts.organizationId,
+    availability: opts.availability ?? DEFAULT_AGENT_AVAILABILITY,
   };
+}
+
+export async function createAgent(page: Page, opts: CreateAgentOptions): Promise<string> {
+  let modelId = opts.model?.trim() ?? '';
+  if (!modelId) {
+    modelId = await ensureModelId(page, opts.organizationId);
+  }
+  const payload = buildCreateAgentPayload(opts, modelId);
   const trimmedNickname = opts.nickname?.trim();
   if (trimmedNickname) {
     payload.nickname = trimmedNickname;


### PR DESCRIPTION
## Summary
- Set console Playwright `createAgent()` payloads to always include valid internal availability by default.
- Added a payload builder with caller override support for private availability.
- Added focused helper tests similar to `chat-api.spec.ts`.

Closes #116
Unblocks agynio/console-app#101 e2e CI.

## Test & lint summary
- `cd suites/playwright && npm ci --no-fund --no-audit` completed successfully.
- `cd suites/playwright && npx buf generate` completed successfully.
- `cd suites/playwright && npm exec -- tsc --noEmit` passed with no type/lint errors.
- `cd suites/playwright && E2E_BASE_URL=http://127.0.0.1 npx playwright test test/e2e/console-api.spec.ts --reporter=line` passed: 2 passed, 0 failed, 0 skipped.