### PR TITLE
fix(chat-app): send CreateAgent protobuf

### DIFF
--- a/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
@@ -1,42 +1,52 @@
 import { test, expect } from '@playwright/test';
 import { AgentAvailability } from '../../src/gen/agynio/api/agents/v1/agents_pb';
-import { buildCreateAgentPayload } from './chat-api';
+import {
+  buildCreateAgentPayload,
+  buildCreateAgentRequestBytes,
+  buildCreateAgentRequestJson,
+} from './chat-api';
+
+const createAgentOptions = {
+  organizationId: 'organization-id',
+  name: 'agent-name',
+  role: 'assistant',
+  model: 'model-id',
+  description: 'description',
+  configuration: '{}',
+  image: 'alpine:3.21',
+  initImage: 'ghcr.io/agynio/agent-init-codex:latest',
+};
 
 test.describe('chat api helpers', () => {
-  test('CreateAgent payload omits default internal availability', () => {
-    const payload = buildCreateAgentPayload({
-      organizationId: 'organization-id',
-      name: 'agent-name',
-      role: 'assistant',
-      model: 'model-id',
-      description: 'description',
-      configuration: '{}',
-      image: 'alpine:3.21',
-      initImage: 'ghcr.io/agynio/agent-init-codex:latest',
-    });
+  test('CreateAgent payload sets internal availability enum', () => {
+    const payload = buildCreateAgentPayload(createAgentOptions);
 
     expect(JSON.parse(JSON.stringify(payload))).toEqual({
-      organizationId: 'organization-id',
-      name: 'agent-name',
-      role: 'assistant',
-      model: 'model-id',
-      description: 'description',
-      configuration: '{}',
-      image: 'alpine:3.21',
-      initImage: 'ghcr.io/agynio/agent-init-codex:latest',
+      ...createAgentOptions,
+      availability: AgentAvailability.INTERNAL,
     });
   });
 
-  test('CreateAgent payload serializes private availability as enum number', () => {
+  test('CreateAgent ConnectRPC JSON uses protobuf enum name', () => {
+    const payload = buildCreateAgentRequestJson(createAgentOptions);
+
+    expect(JSON.parse(JSON.stringify(payload))).toEqual({
+      ...createAgentOptions,
+      availability: 'AGENT_AVAILABILITY_INTERNAL',
+    });
+  });
+
+  test('CreateAgent ConnectRPC proto bytes include availability value', () => {
+    const payload = buildCreateAgentRequestBytes(createAgentOptions);
+
+    expect(Buffer.from(payload).toString('hex')).toBe(
+      '0a0a6167656e742d6e616d651209617373697374616e741a086d6f64656c2d6964220b6465736372697074696f6e2a027b7d320b616c70696e653a332e3231420f6f7267616e697a6174696f6e2d69644a26676863722e696f2f6167796e696f2f6167656e742d696e69742d636f6465783a6c61746573746801',
+    );
+  });
+
+  test('CreateAgent payload serializes private availability enum', () => {
     const payload = buildCreateAgentPayload({
-      organizationId: 'organization-id',
-      name: 'agent-name',
-      role: 'assistant',
-      model: 'model-id',
-      description: 'description',
-      configuration: '{}',
-      image: 'alpine:3.21',
-      initImage: 'ghcr.io/agynio/agent-init-codex:latest',
+      ...createAgentOptions,
       availability: AgentAvailability.PRIVATE,
     });
 

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -1,5 +1,7 @@
+import { create, fromBinary, toBinary, toJson } from '@bufbuild/protobuf';
+import type { DescMessage, MessageShape } from '@bufbuild/protobuf';
 import type { Page } from '@playwright/test';
-import { AgentAvailability } from '../../src/gen/agynio/api/agents/v1/agents_pb';
+import { AgentAvailability, CreateAgentRequestSchema, CreateAgentResponseSchema } from '../../src/gen/agynio/api/agents/v1/agents_pb';
 
 const CHAT_GATEWAY_PATH = '/api/agynio.api.gateway.v1.ChatGateway';
 const AGENTS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.AgentsGateway';
@@ -13,8 +15,13 @@ export const DEFAULT_TEST_INIT_IMAGE =
   'ghcr.io/agynio/agent-init-codex:latest';
 export const DEFAULT_TEST_AGENT_IMAGE = 'alpine:3.21';
 
-const CONNECT_HEADERS = {
+const CONNECT_JSON_HEADERS = {
   'Content-Type': 'application/json',
+  'Connect-Protocol-Version': '1',
+};
+
+const CONNECT_PROTO_HEADERS = {
+  'Content-Type': 'application/proto',
   'Connect-Protocol-Version': '1',
 };
 
@@ -137,6 +144,12 @@ type OidcStorageSnapshot = {
   accessToken: string | null;
 };
 
+type PostConnectProtoOptions<InputSchema extends DescMessage, OutputSchema extends DescMessage> = {
+  encoding: 'proto';
+  inputSchema: InputSchema;
+  outputSchema: OutputSchema;
+};
+
 function redactPayload(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((entry) => redactPayload(entry));
@@ -186,10 +199,31 @@ async function postConnect<T>(
   servicePath: string,
   method: string,
   payload: unknown,
+  options?: PostConnectProtoOptions<DescMessage, DescMessage>,
 ): Promise<T> {
   const session = await readOidcSession(page);
   const token = session?.accessToken ?? null;
-  const headers = token ? { ...CONNECT_HEADERS, Authorization: `Bearer ${token}` } : CONNECT_HEADERS;
+  if (options?.encoding === 'proto') {
+    const headers = token ? { ...CONNECT_PROTO_HEADERS, Authorization: `Bearer ${token}` } : CONNECT_PROTO_HEADERS;
+    const message = payload as MessageShape<typeof options.inputSchema>;
+    const requestBody = Buffer.from(toBinary(options.inputSchema, message));
+    const response = await page.context().request.post(buildRpcUrl(servicePath, method), {
+      data: requestBody,
+      headers,
+    });
+    if (!response.ok()) {
+      const body = await response.text();
+      if (method === 'CreateAgent') {
+        console.error(`ConnectRPC ${method} request JSON: ${formatDebugPayload(toJson(options.inputSchema, message))}`);
+        console.error(`ConnectRPC ${method} request proto hex: ${requestBody.toString('hex')}`);
+      }
+      throw new Error(`ConnectRPC ${method} failed with status ${response.status()}: ${body}`);
+    }
+    const responseBody = Buffer.from(await response.body());
+    return fromBinary(options.outputSchema, responseBody) as T;
+  }
+
+  const headers = token ? { ...CONNECT_JSON_HEADERS, Authorization: `Bearer ${token}` } : CONNECT_JSON_HEADERS;
   const response = await page.context().request.post(buildRpcUrl(servicePath, method), {
     data: payload,
     headers,
@@ -415,7 +449,7 @@ type CreateAgentOptions = {
 };
 
 type CreateAgentPayload = Omit<CreateAgentOptions, 'availability'> & {
-  availability?: number;
+  availability: AgentAvailability.INTERNAL | AgentAvailability.PRIVATE;
 };
 
 type SetupTestAgentOptions = {
@@ -457,14 +491,22 @@ export async function createAgent(page: Page, opts: CreateAgentOptions): Promise
     throw new Error('initImage is required to create chat agents.');
   }
   const payload = buildCreateAgentPayload({ ...rest, initImage: trimmedInitImage });
+  const request = create(CreateAgentRequestSchema, payload);
   if (DEBUG_CREATE_AGENT_PAYLOAD) {
-    console.info(`ConnectRPC CreateAgent request JSON: ${formatDebugPayload(payload)}`);
+    const requestBody = Buffer.from(buildCreateAgentRequestBytes(payload));
+    console.info(`ConnectRPC CreateAgent request JSON: ${formatDebugPayload(toJson(CreateAgentRequestSchema, request))}`);
+    console.info(`ConnectRPC CreateAgent request proto hex: ${requestBody.toString('hex')}`);
   }
   const response = await postConnect<CreateAgentResponseWire>(
     page,
     AGENTS_GATEWAY_PATH,
     'CreateAgent',
-    payload,
+    request,
+    {
+      encoding: 'proto',
+      inputSchema: CreateAgentRequestSchema,
+      outputSchema: CreateAgentResponseSchema,
+    },
   );
   if (!response.agent?.meta?.id) {
     throw new Error('CreateAgent response missing agent id.');
@@ -479,10 +521,15 @@ export function buildCreateAgentPayload(opts: CreateAgentOptions): CreateAgentPa
   if (availability !== AgentAvailability.INTERNAL && availability !== AgentAvailability.PRIVATE) {
     throw new Error(`Unsupported agent availability: ${availability}`);
   }
-  if (availability === AgentAvailability.INTERNAL) {
-    return rest;
-  }
   return { ...rest, availability };
+}
+
+export function buildCreateAgentRequestJson(opts: CreateAgentOptions): unknown {
+  return toJson(CreateAgentRequestSchema, create(CreateAgentRequestSchema, buildCreateAgentPayload(opts)));
+}
+
+export function buildCreateAgentRequestBytes(opts: CreateAgentOptions): Uint8Array {
+  return toBinary(CreateAgentRequestSchema, create(CreateAgentRequestSchema, buildCreateAgentPayload(opts)));
 }
 
 export async function createTestModel(


### PR DESCRIPTION
## Summary
- Switch chat-app e2e `CreateAgent` to use Connect unary protobuf (`Content-Type: application/proto`) for `AgentsGateway/CreateAgent` while keeping the same `postConnect` helper path.
- Keep debug evidence by logging both protobuf JSON (`availability: AGENT_AVAILABILITY_INTERNAL`) and exact protobuf hex when CreateAgent fails or debug is enabled.
- Add focused tests for the internal enum payload, canonical protobuf JSON evidence, and exact serialized protobuf bytes containing field 13 value 1 (`...6801`).

## Evidence
- Gateway proto defines `AgentAvailability` enum values: `AGENT_AVAILABILITY_INTERNAL = 1`, `AGENT_AVAILABILITY_PRIVATE = 2`.
- Connect-Go JSON codec uses `protojson`, so canonical JSON is `"availability":"AGENT_AVAILABILITY_INTERNAL"`.
- Previous CI proved JSON was still decoded as unspecified by the deployed path, so this PR sends the accepted protobuf wire representation instead: field `13` (`0x68`) with enum value `1` (`0x01`).

## Test & lint summary
- `cd suites/playwright-chat-app && npm ci --no-fund --no-audit` completed successfully.
- `cd suites/playwright-chat-app && npx buf generate` completed successfully.
- `cd suites/playwright-chat-app && E2E_BASE_URL=http://127.0.0.1 npx tsc --noEmit` passed with no type/lint errors.
- `cd suites/playwright-chat-app && E2E_BASE_URL=http://127.0.0.1 npx playwright test test/e2e/chat-api.spec.ts --reporter=list` passed: 4 passed, 0 failed, 0 skipped.