### PR TITLE
fix(console): send lowercase agent availability

### DIFF
--- a/suites/playwright/test/e2e/console-api.spec.ts
+++ b/suites/playwright/test/e2e/console-api.spec.ts
@@ -12,7 +12,7 @@ test.describe('console api helpers', () => {
     );
 
     expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
-      availability: 'AGENT_AVAILABILITY_INTERNAL',
+      availability: 'internal',
     });
   });
 
@@ -21,13 +21,13 @@ test.describe('console api helpers', () => {
       {
         organizationId: 'organization-id',
         name: 'agent-name',
-        availability: 'AGENT_AVAILABILITY_PRIVATE',
+        availability: 'private',
       },
       'model-id',
     );
 
     expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
-      availability: 'AGENT_AVAILABILITY_PRIVATE',
+      availability: 'private',
     });
   });
 });

--- a/suites/playwright/test/e2e/console-api.ts
+++ b/suites/playwright/test/e2e/console-api.ts
@@ -287,9 +287,9 @@ type MembershipStatusValue =
   | 'MEMBERSHIP_STATUS_UNSPECIFIED'
   | 'MEMBERSHIP_STATUS_PENDING'
   | 'MEMBERSHIP_STATUS_ACTIVE';
-type AgentAvailabilityValue = 'AGENT_AVAILABILITY_INTERNAL' | 'AGENT_AVAILABILITY_PRIVATE';
+type AgentAvailabilityValue = 'internal' | 'private';
 
-const DEFAULT_AGENT_AVAILABILITY: AgentAvailabilityValue = 'AGENT_AVAILABILITY_INTERNAL';
+const DEFAULT_AGENT_AVAILABILITY: AgentAvailabilityValue = 'internal';
 
 type CreateAgentOptions = {
   organizationId: string;


### PR DESCRIPTION
## Summary
- Follow-up to #117 for #116: send console `CreateAgent` availability as backend wire values (`internal` / `private`) instead of enum names.
- Updated the console helper tests to assert the lowercase payload values.
- Verified the failing console-app run was using the merged e2e fix but still hit `availability: must be internal or private`.

Closes #116
Unblocks agynio/console-app main e2e CI.

## Test & lint summary
- `cd suites/playwright && npm ci --no-fund --no-audit` completed successfully.
- `cd suites/playwright && npx buf generate` completed successfully.
- `cd suites/playwright && npm exec -- tsc --noEmit` passed with no type/lint errors.
- `cd suites/playwright && E2E_BASE_URL=http://127.0.0.1 npx playwright test test/e2e/console-api.spec.ts --reporter=line` passed: 2 passed, 0 failed, 0 skipped.