### PR TITLE
fix(console): send CreateAgent protobuf

### DIFF
--- a/suites/playwright/test/e2e/console-api.spec.ts
+++ b/suites/playwright/test/e2e/console-api.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { buildCreateAgentPayload } from './console-api';
+import { AgentAvailability } from '../../src/gen/agynio/api/agents/v1/agents_pb';
+import { buildCreateAgentPayload, buildCreateAgentRequestBytes, buildCreateAgentRequestJson } from './console-api';
 
 test.describe('console api helpers', () => {
   test('CreateAgent payload defaults availability to internal', () => {
@@ -12,7 +13,7 @@ test.describe('console api helpers', () => {
     );
 
     expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
-      availability: 'internal',
+      availability: AgentAvailability.INTERNAL,
     });
   });
 
@@ -21,13 +22,41 @@ test.describe('console api helpers', () => {
       {
         organizationId: 'organization-id',
         name: 'agent-name',
-        availability: 'private',
+        availability: AgentAvailability.PRIVATE,
       },
       'model-id',
     );
 
     expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
-      availability: 'private',
+      availability: AgentAvailability.PRIVATE,
     });
+  });
+
+  test('CreateAgent ConnectRPC JSON uses protobuf enum name', () => {
+    const payload = buildCreateAgentRequestJson(
+      {
+        organizationId: 'organization-id',
+        name: 'agent-name',
+      },
+      'model-id',
+    );
+
+    expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
+      availability: 'AGENT_AVAILABILITY_INTERNAL',
+    });
+  });
+
+  test('CreateAgent ConnectRPC proto bytes include availability value', () => {
+    const payload = buildCreateAgentRequestBytes(
+      {
+        organizationId: 'organization-id',
+        name: 'agent-name',
+      },
+      'model-id',
+    );
+
+    expect(Buffer.from(payload).toString('hex')).toBe(
+      '0a0a6167656e742d6e616d651209617373697374616e741a086d6f64656c2d6964420f6f7267616e697a6174696f6e2d69646801',
+    );
   });
 });

--- a/suites/playwright/test/e2e/console-api.ts
+++ b/suites/playwright/test/e2e/console-api.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@connectrpc/connect';
 import { createGrpcTransport } from '@connectrpc/connect-node';
-import { create, toJson } from '@bufbuild/protobuf';
+import { create, fromBinary, toBinary, toJson } from '@bufbuild/protobuf';
+import type { DescMessage, MessageShape } from '@bufbuild/protobuf';
 import { TimestampSchema, type Timestamp } from '@bufbuild/protobuf/wkt';
 import { randomUUID } from 'crypto';
 import type { Page } from '@playwright/test';
@@ -11,6 +12,11 @@ import {
   Unit,
   UsageRecordSchema,
 } from '../../src/gen/agynio/api/metering/v1/metering_pb';
+import {
+  AgentAvailability,
+  CreateAgentRequestSchema,
+  CreateAgentResponseSchema,
+} from '../../src/gen/agynio/api/agents/v1/agents_pb';
 import { readOidcSession } from './oidc-helpers';
 
 const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
@@ -24,6 +30,11 @@ const METERING_GATEWAY_PATH = '/api/agynio.api.gateway.v1.MeteringGateway';
 
 const CONNECT_HEADERS = {
   'Content-Type': 'application/json',
+  'Connect-Protocol-Version': '1',
+};
+
+const CONNECT_PROTO_HEADERS = {
+  'Content-Type': 'application/proto',
   'Connect-Protocol-Version': '1',
 };
 
@@ -287,9 +298,9 @@ type MembershipStatusValue =
   | 'MEMBERSHIP_STATUS_UNSPECIFIED'
   | 'MEMBERSHIP_STATUS_PENDING'
   | 'MEMBERSHIP_STATUS_ACTIVE';
-type AgentAvailabilityValue = 'internal' | 'private';
+type AgentAvailabilityValue = AgentAvailability.INTERNAL | AgentAvailability.PRIVATE;
 
-const DEFAULT_AGENT_AVAILABILITY: AgentAvailabilityValue = 'internal';
+const DEFAULT_AGENT_AVAILABILITY: AgentAvailabilityValue = AgentAvailability.INTERNAL;
 
 type CreateAgentOptions = {
   organizationId: string;
@@ -383,14 +394,45 @@ function isClusterAdminRole(role: ClusterRoleWire): boolean {
   return role === 'CLUSTER_ROLE_ADMIN';
 }
 
+type PostConnectProtoOptions<InputSchema extends DescMessage, OutputSchema extends DescMessage> = {
+  encoding: 'proto';
+  inputSchema: InputSchema;
+  outputSchema: OutputSchema;
+};
+
+function formatCreateAgentDebugPayload(payload: unknown): string {
+  return JSON.stringify(payload);
+}
+
 async function postConnect<T>(
   page: Page,
   servicePath: string,
   method: string,
-  payload: Record<string, unknown>,
+  payload: Record<string, unknown> | MessageShape<DescMessage>,
+  options?: PostConnectProtoOptions<DescMessage, DescMessage>,
 ): Promise<T> {
   const session = await readOidcSession(page);
   const token = session?.accessToken ?? null;
+  if (options?.encoding === 'proto') {
+    const headers = token ? { ...CONNECT_PROTO_HEADERS, Authorization: `Bearer ${token}` } : CONNECT_PROTO_HEADERS;
+    const message = payload as MessageShape<typeof options.inputSchema>;
+    const requestBody = Buffer.from(toBinary(options.inputSchema, message));
+    const response = await page.context().request.post(buildRpcUrl(servicePath, method), {
+      data: requestBody,
+      headers,
+    });
+    if (!response.ok()) {
+      const body = await response.text();
+      if (method === 'CreateAgent') {
+        console.error(`ConnectRPC ${method} request JSON: ${formatCreateAgentDebugPayload(toJson(options.inputSchema, message))}`);
+        console.error(`ConnectRPC ${method} request proto hex: ${requestBody.toString('hex')}`);
+      }
+      throw new Error(`ConnectRPC ${method} failed with status ${response.status()}: ${body}`);
+    }
+    const responseBody = Buffer.from(await response.body());
+    return fromBinary(options.outputSchema, responseBody) as T;
+  }
+
   const headers = token ? { ...CONNECT_HEADERS, Authorization: `Bearer ${token}` } : CONNECT_HEADERS;
   const response = await page.context().request.post(buildRpcUrl(servicePath, method), {
     data: payload,
@@ -398,6 +440,9 @@ async function postConnect<T>(
   });
   if (!response.ok()) {
     const body = await response.text();
+    if (method === 'CreateAgent') {
+      console.error(`ConnectRPC ${method} request JSON: ${formatCreateAgentDebugPayload(payload)}`);
+    }
     throw new Error(`ConnectRPC ${method} failed with status ${response.status()}: ${body}`);
   }
   return (await response.json()) as T;
@@ -899,6 +944,14 @@ export function buildCreateAgentPayload(opts: CreateAgentOptions, modelId: strin
   };
 }
 
+export function buildCreateAgentRequestJson(opts: CreateAgentOptions, modelId: string): unknown {
+  return toJson(CreateAgentRequestSchema, create(CreateAgentRequestSchema, buildCreateAgentPayload(opts, modelId)));
+}
+
+export function buildCreateAgentRequestBytes(opts: CreateAgentOptions, modelId: string): Uint8Array {
+  return toBinary(CreateAgentRequestSchema, create(CreateAgentRequestSchema, buildCreateAgentPayload(opts, modelId)));
+}
+
 export async function createAgent(page: Page, opts: CreateAgentOptions): Promise<string> {
   let modelId = opts.model?.trim() ?? '';
   if (!modelId) {
@@ -909,7 +962,18 @@ export async function createAgent(page: Page, opts: CreateAgentOptions): Promise
   if (trimmedNickname) {
     payload.nickname = trimmedNickname;
   }
-  const response = await postConnect<CreateAgentResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateAgent', payload);
+  const request = create(CreateAgentRequestSchema, payload);
+  const response = await postConnect<CreateAgentResponseWire>(
+    page,
+    AGENTS_GATEWAY_PATH,
+    'CreateAgent',
+    request,
+    {
+      encoding: 'proto',
+      inputSchema: CreateAgentRequestSchema,
+      outputSchema: CreateAgentResponseSchema,
+    },
+  );
   const agentId = response.agent?.meta?.id;
   if (!agentId) {
     throw new Error('CreateAgent response missing agent id.');


### PR DESCRIPTION
## Summary
- Follow-up to #116 after console-app main still failed on e2e commit `07fed87b`.
- Root cause: raw Connect JSON for `CreateAgent` was not accepted by the backend enum validation; the exact protobuf JSON shape is `availability: AGENT_AVAILABILITY_INTERNAL`, and the successful wire payload is protobuf binary with field 13 set to `1`.
- Matched the already-merged chat-app fix by sending console `CreateAgent` via Connect protobuf (`Content-Type: application/proto`) using `CreateAgentRequestSchema` / `CreateAgentResponseSchema`.
- Added debug logging for failed `CreateAgent` requests with protobuf JSON and proto hex, so any future failure shows the exact payload.
- Expanded tests to assert helper payload enum values, protobuf JSON shape, and exact protobuf bytes containing availability.

Closes #116
Unblocks agynio/console-app main e2e CI.

## Test & lint summary
- `cd suites/playwright && npm ci --no-fund --no-audit` completed successfully.
- `cd suites/playwright && npx buf generate` completed successfully.
- `cd suites/playwright && npm exec -- tsc --noEmit` passed with no type/lint errors.
- `cd suites/playwright && E2E_BASE_URL=http://127.0.0.1 npx playwright test test/e2e/console-api.spec.ts --reporter=line` passed: 4 passed, 0 failed, 0 skipped.