### PR TITLE
fix(e2e): pin codex init image with ziti auth fix

### DIFF
--- a/.github/workflows/agn-cli-e2e.yml
+++ b/.github/workflows/agn-cli-e2e.yml
@@ -12,8 +12,7 @@ jobs:
     permissions:
       contents: read
     env:
-      AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
-      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.27
       AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
       CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
       AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,8 +16,7 @@ jobs:
     permissions:
       contents: read
     env:
-      AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
-      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.27
       AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
       CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
       AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4


### PR DESCRIPTION
## Summary\n- Pin CODEX_INIT_IMAGE to agent-init-codex:0.13.27 in E2E workflows.\n- Remove the stale AGYN_AGENT_INIT_IMAGE override so chat-app's default Codex setup is not forced to ghcr.io/agynio/agent-init:v1.0.0.\n- This pulls agynd-cli 0.14.16, which scrubs host Codex auth env for *.ziti LLM endpoints.\n\n## Why\nThe chat-app rerun no longer has llm-proxy 403s, but codex agent runs still fail because CODEX_INIT_IMAGE resolves to the floating 0.13 tag. In the job it resolved to 0.13.20, older than agent-init-codex 0.13.27 / agynd 0.14.16. The old agynd lets Codex use ambient auth instead of the platform LLM proxy for ziti endpoints, producing TestLLM mismatches and no agent replies.\n\n## Validation\n- Inspected chat-app job 77068320704 logs/artifacts.\n- Confirmed no llm-proxy 403s.\n- Confirmed failing codex runs use ghcr.io/agynio/agent-init-codex:0.13.20 from the floating 0.13 tag.\n- git diff --check\n