### PR TITLE
fix(chat-app): stop injecting LLM API token into test agents

### DIFF
--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -66,10 +66,6 @@ type CreateMembershipResponseWire = {
   membership?: { id?: string };
 };
 
-type CreateAPITokenResponseWire = {
-  plaintextToken?: string;
-};
-
 type GetMeResponseWire = {
   user?: { meta?: { id?: string } };
 };
@@ -354,20 +350,6 @@ export async function createMembership(
   return response.membership.id;
 }
 
-export async function createApiToken(page: Page, name: string): Promise<string> {
-  const response = await postConnect<CreateAPITokenResponseWire>(
-    page,
-    USERS_GATEWAY_PATH,
-    'CreateAPIToken',
-    { name },
-  );
-  const token = response.plaintextToken;
-  if (!token) {
-    throw new Error('CreateAPIToken response missing plaintext token.');
-  }
-  return token;
-}
-
 export async function acceptMembership(page: Page, membershipId: string): Promise<void> {
   await postConnect(page, ORGS_GATEWAY_PATH, 'AcceptMembership', { membershipId });
 }
@@ -563,7 +545,6 @@ export async function setupTestAgent(
   const now = Date.now();
   const organizationId = await createOrganization(page, `e2e-org-llm-${now}`);
   const initImage = resolveCodexInitImage(opts.initImage);
-  const apiToken = await createApiToken(page, `e2e-agent-token-${now}`);
 
   const { modelId } = await createTestModel(page, {
     organizationId,
@@ -586,7 +567,6 @@ export async function setupTestAgent(
     image: DEFAULT_TEST_AGENT_IMAGE,
     initImage,
   });
-  await createAgentEnv(page, agentId, 'LLM_API_TOKEN', apiToken);
   const participantId = agentId;
 
   return { organizationId, agentId, agentName, participantId };


### PR DESCRIPTION
## Summary\n- Remove chat-app test agent API token creation from setupTestAgent.\n- Stop injecting LLM_API_TOKEN into in-cluster chat-app test agents.\n\n## Why\nThese agents use llm-proxy.ziti, where caller auth should be the agent Ziti identity. Injecting a real user API token into LLM_API_TOKEN lets SDKs accidentally send Authorization: Bearer agyn_..., causing llm-proxy to resolve the caller as a user instead of the agent.\n\n## Validation\n- git diff --check\n