### PR TITLE
Fix chat-app TestLLM input mismatches

### DIFF
--- a/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { expect, type Page } from '@playwright/test';
 import { test } from './fixtures';
 import {
@@ -131,7 +130,7 @@ test.describe('chat trace link', {
       const chatId = await createChat(page, organizationId, participantId);
       await setSelectedOrganization(page, organizationId);
 
-      const messageText = `trace-${scenario.name}-${randomUUID()}`;
+      const messageText = 'hello';
       await sendChatMessage(page, chatId, messageText);
 
       await waitForAgentReply(page, chatId, identityId, 180_000);

--- a/suites/playwright-chat-app/test/e2e/inline-media.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/inline-media.spec.ts
@@ -3,13 +3,11 @@ import type { Page } from '@playwright/test';
 import { expect, test } from './fixtures';
 import {
   createChat,
+  createOrganization,
+  resolveIdentityId,
   sendChatMessage,
-  setupTestAgent,
 } from './chat-api';
 import { setSelectedOrganization } from './organization-helpers';
-
-const defaultTestLlmEndpoint = 'https://testllm.dev/v1/org/agynio/suite/codex/responses';
-const llmEndpoint = process.env.E2E_TEST_LLM_ENDPOINT ?? defaultTestLlmEndpoint;
 
 const mermaidSource = `graph TD
     A[Start] --> B{Decision}
@@ -36,19 +34,14 @@ const vegaLiteSource = JSON.stringify({
 });
 
 async function openChat(page: Page, message: string): Promise<void> {
-  const { organizationId, participantId } = await setupTestAgent(page, {
-    endpoint: llmEndpoint,
-    initImage: process.env.E2E_AGENT_INIT_IMAGE,
-  });
+  const now = Date.now();
+  const organizationId = await createOrganization(page, `e2e-org-inline-media-${now}`);
+  const participantId = await resolveIdentityId(page);
   const chatId = await createChat(page, organizationId, participantId);
   await setSelectedOrganization(page, organizationId);
   await sendChatMessage(page, chatId, message);
-  const chatLoaded = page.waitForResponse(
-    (resp) => resp.url().includes('GetMessages') && resp.status() === 200,
-    { timeout: 15000 },
-  );
   await page.goto(`/chats/${encodeURIComponent(chatId)}`);
-  await chatLoaded;
+  await expect(page.getByTestId('chat-message').filter({ hasText: message })).toBeVisible({ timeout: 15000 });
 }
 
 function mermaidMessage(source: string): string {
@@ -63,7 +56,6 @@ test.describe('inline-media', {
   tag: [
     '@svc_chat_app',
     '@svc_gateway',
-    '@svc_agents_orchestrator',
     '@svc_organizations',
     '@svc_files',
     '@svc_media_proxy',


### PR DESCRIPTION
## Summary

- Fixes #126
- Updates chat trace-link E2E to send `hello`, matching the default TestLLM `simple-hello` scenario.
- Removes unnecessary simple-hello agent setup from inline media E2E, so Mermaid/Vega markdown prompts no longer trigger background TestLLM `input_mismatch` errors.
- Removes `@svc_agents_orchestrator` from inline media because the spec no longer creates or exercises agents.

## Validation

- `npx buf generate`
- `npx tsc --noEmit`
- `E2E_BASE_URL=https://chat.agyn.dev CI=true npx playwright test test/e2e/chat-api.spec.ts --project=chromium --workers=1 --retries=0`

## Notes

Targeted full specs were attempted against `https://chat.agyn.dev`; they still fail in the current deployed environment for issues outside this PR's e2e changes:

- `chat-trace-link.spec.ts` still lands on `/message/<id>` instead of `/runs/<id>`, matching the known tracing-app one-shot `findRunByMessageId` polling gap.
- `inline-media.spec.ts` now avoids agent/TestLLM mismatches, but the current app renders the fenced markdown as code blocks instead of the expected Mermaid/Vega widgets in this environment.