### PR TITLE
fix(chat-app): wait for rendered inline media messages

### DIFF
--- a/suites/playwright-chat-app/test/e2e/inline-media.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/inline-media.spec.ts
@@ -40,8 +40,13 @@ async function openChat(page: Page, message: string): Promise<void> {
   const chatId = await createChat(page, organizationId, participantId);
   await setSelectedOrganization(page, organizationId);
   await sendChatMessage(page, chatId, message);
+  const chatLoaded = page.waitForResponse(
+    (resp) => resp.url().includes('GetMessages') && resp.status() === 200,
+    { timeout: 15000 },
+  );
   await page.goto(`/chats/${encodeURIComponent(chatId)}`);
-  await expect(page.getByTestId('chat-message').filter({ hasText: message })).toBeVisible({ timeout: 15000 });
+  await chatLoaded;
+  await expect(page.getByTestId('chat-message')).toBeVisible({ timeout: 15000 });
 }
 
 function mermaidMessage(source: string): string {


### PR DESCRIPTION
The chat-app inline media tests were waiting for the raw fenced Markdown message text to remain visible. After chat-app correctly renders mermaid and vega-lite fences into diagrams/charts, that raw source is intentionally removed from the visible message text, so the tests timed out before checking the rendered diagram/chart.

This changes openChat to wait for GetMessages and for any chat message row to render. The individual tests still assert the specific markdown-mermaid / markdown-vega-lite or error UI.

Validation:
- npm ci --ignore-scripts
- npx tsc --noEmit (blocked by pre-existing missing generated protobuf imports in chat-api files; this change itself is type-local to inline-media.spec.ts)