### PR TITLE
fix(go-core): create LLM resources via gateway

### DIFF
--- a/suites/go-core/tests/gateway_helpers_test.go
+++ b/suites/go-core/tests/gateway_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && (svc_gateway || svc_llm || svc_llm_proxy || smoke)
+//go:build e2e && (svc_gateway || svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || svc_llm || svc_llm_proxy || smoke)
 
 package tests
 

--- a/suites/go-core/tests/llm_gateway_helpers_test.go
+++ b/suites/go-core/tests/llm_gateway_helpers_test.go
@@ -1,0 +1,186 @@
+//go:build e2e && (svc_agents_orchestrator || svc_llm || svc_llm_proxy || smoke)
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
+	"github.com/google/uuid"
+)
+
+const (
+	llmGatewayServicePath   = "agynio.api.gateway.v1.LLMGateway"
+	llmProviderTestEndpoint = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+)
+
+func createGatewayLLMProvider(t *testing.T, ctx context.Context, token string, organizationID string) (string, error) {
+	t.Helper()
+	provider, err := createGatewayLLMProviderResource(
+		t,
+		ctx,
+		token,
+		llmProviderTestEndpoint,
+		"AUTH_METHOD_X_API_KEY",
+		"e2e-test-token",
+		organizationID,
+		llmv1.Protocol_PROTOCOL_RESPONSES,
+	)
+	if err != nil {
+		return "", err
+	}
+	return provider.GetMeta().GetId(), nil
+}
+
+func createGatewayLLMProviderResource(
+	t *testing.T,
+	ctx context.Context,
+	token string,
+	endpoint string,
+	authMethod string,
+	providerToken string,
+	organizationID string,
+	protocol llmv1.Protocol,
+) (*llmv1.LLMProvider, error) {
+	t.Helper()
+	resp, err := postGatewayConnect[gatewayCreateLLMProviderResponse](t, ctx, token, "CreateLLMProvider", map[string]string{
+		"endpoint":       endpoint,
+		"authMethod":     authMethod,
+		"token":          providerToken,
+		"organizationId": organizationID,
+		"protocol":       protocol.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	providerID := strings.TrimSpace(resp.Provider.Meta.ID)
+	if providerID == "" {
+		return nil, fmt.Errorf("provider id missing")
+	}
+	return &llmv1.LLMProvider{Meta: &llmv1.EntityMeta{Id: providerID}}, nil
+}
+
+func createGatewayLLMModel(t *testing.T, ctx context.Context, token string, organizationID string, providerID string) (string, error) {
+	t.Helper()
+	model, err := createGatewayLLMModelResource(
+		t,
+		ctx,
+		token,
+		fmt.Sprintf("e2e-llm-proxy-%s", uuid.NewString()),
+		organizationID,
+		providerID,
+		"simple-hello",
+	)
+	if err != nil {
+		return "", err
+	}
+	return model.GetMeta().GetId(), nil
+}
+
+func createGatewayLLMModelResource(
+	t *testing.T,
+	ctx context.Context,
+	token string,
+	name string,
+	organizationID string,
+	providerID string,
+	remoteName string,
+) (*llmv1.Model, error) {
+	t.Helper()
+	resp, err := postGatewayConnect[gatewayCreateModelResponse](t, ctx, token, "CreateModel", map[string]string{
+		"name":           name,
+		"llmProviderId":  providerID,
+		"remoteName":     remoteName,
+		"organizationId": organizationID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	modelID := strings.TrimSpace(resp.Model.Meta.ID)
+	if modelID == "" {
+		return nil, fmt.Errorf("model id missing")
+	}
+	return &llmv1.Model{Meta: &llmv1.EntityMeta{Id: modelID}}, nil
+}
+
+type gatewayCreateLLMProviderResponse struct {
+	Provider gatewayLLMEntity `json:"provider"`
+}
+
+type gatewayCreateModelResponse struct {
+	Model gatewayLLMEntity `json:"model"`
+}
+
+type gatewayLLMEntity struct {
+	Meta gatewayEntityMeta `json:"meta"`
+}
+
+type gatewayEntityMeta struct {
+	ID string `json:"id"`
+}
+
+func postGatewayConnect[T any](t *testing.T, ctx context.Context, token string, method string, payload any) (T, error) {
+	t.Helper()
+	var response T
+	body, statusCode := postGatewayConnectRaw(t, ctx, token, method, payload)
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return response, fmt.Errorf("gateway %s failed with status %d: %s", method, statusCode, body)
+	}
+
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		return response, fmt.Errorf("decode gateway %s response: %w", method, err)
+	}
+	return response, nil
+}
+
+func postGatewayConnectBestEffort(t *testing.T, ctx context.Context, token string, method string, payload any) {
+	t.Helper()
+	_, _ = postGatewayConnectRaw(t, ctx, token, method, payload)
+}
+
+func postGatewayConnectRaw(t *testing.T, ctx context.Context, token string, method string, payload any) (string, int) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal gateway %s request: %v", method, err)
+	}
+
+	endpoint := gatewayLLMConnectEndpoint(t, method)
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build gateway %s request: %v", method, err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Connect-Protocol-Version", "1")
+	request.Header.Set("Authorization", "Bearer "+token)
+
+	response, err := newGatewayClient(t).Do(request)
+	if err != nil {
+		t.Fatalf("post gateway %s: %v", method, err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read gateway %s response: %v", method, err)
+	}
+	return strings.TrimSpace(string(responseBody)), response.StatusCode
+}
+
+func gatewayLLMConnectEndpoint(t *testing.T, method string) string {
+	t.Helper()
+	endpoint, err := url.JoinPath(gatewayBaseURL(t), llmGatewayServicePath, method)
+	if err != nil {
+		t.Fatalf("build gateway %s url: %v", method, err)
+	}
+	return endpoint
+}

--- a/suites/go-core/tests/llm_proxy_test.go
+++ b/suites/go-core/tests/llm_proxy_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -17,7 +16,6 @@ import (
 	authorizationv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/authorization/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	usersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/users/v1"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -27,8 +25,6 @@ import (
 const (
 	llmProxyURLDefault      = "https://llm.agyn.dev:2496"
 	llmProxyRequestTimeout  = 45 * time.Second
-	llmGatewayServicePath   = "agynio.api.gateway.v1.LLMGateway"
-	llmProviderTestEndpoint = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
 	llmProxyIdentityType    = "user"
 	llmProxyAuthzAddr       = "authorization:50051"
 	llmProxyIdentityKey     = "x-identity-id"
@@ -144,117 +140,6 @@ func llmProxyAdminContext(ctx context.Context) context.Context {
 		llmProxyIdentityKey, clusterAdminIdentityID,
 		llmProxyIdentityTypeKey, llmProxyIdentityType,
 	))
-}
-
-func createGatewayLLMProvider(t *testing.T, ctx context.Context, token string, organizationID string) (string, error) {
-	t.Helper()
-	resp, err := postGatewayConnect[gatewayCreateLLMProviderResponse](t, ctx, token, "CreateLLMProvider", map[string]string{
-		"endpoint":       llmProviderTestEndpoint,
-		"authMethod":     "AUTH_METHOD_X_API_KEY",
-		"token":          "e2e-test-token",
-		"organizationId": organizationID,
-		"protocol":       "PROTOCOL_RESPONSES",
-	})
-	if err != nil {
-		return "", err
-	}
-	providerID := strings.TrimSpace(resp.Provider.Meta.ID)
-	if providerID == "" {
-		return "", fmt.Errorf("provider id missing")
-	}
-	return providerID, nil
-}
-
-func createGatewayLLMModel(t *testing.T, ctx context.Context, token string, organizationID string, providerID string) (string, error) {
-	t.Helper()
-	resp, err := postGatewayConnect[gatewayCreateModelResponse](t, ctx, token, "CreateModel", map[string]string{
-		"name":           fmt.Sprintf("e2e-llm-proxy-%s", uuid.NewString()),
-		"llmProviderId":  providerID,
-		"remoteName":     "simple-hello",
-		"organizationId": organizationID,
-	})
-	if err != nil {
-		return "", err
-	}
-	modelID := strings.TrimSpace(resp.Model.Meta.ID)
-	if modelID == "" {
-		return "", fmt.Errorf("model id missing")
-	}
-	return modelID, nil
-}
-
-type gatewayCreateLLMProviderResponse struct {
-	Provider gatewayLLMEntity `json:"provider"`
-}
-
-type gatewayCreateModelResponse struct {
-	Model gatewayLLMEntity `json:"model"`
-}
-
-type gatewayLLMEntity struct {
-	Meta gatewayEntityMeta `json:"meta"`
-}
-
-type gatewayEntityMeta struct {
-	ID string `json:"id"`
-}
-
-func postGatewayConnect[T any](t *testing.T, ctx context.Context, token string, method string, payload any) (T, error) {
-	t.Helper()
-	var response T
-	body, statusCode := postGatewayConnectRaw(t, ctx, token, method, payload)
-	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
-		return response, fmt.Errorf("gateway %s failed with status %d: %s", method, statusCode, body)
-	}
-
-	if err := json.Unmarshal([]byte(body), &response); err != nil {
-		return response, fmt.Errorf("decode gateway %s response: %w", method, err)
-	}
-	return response, nil
-}
-
-func postGatewayConnectBestEffort(t *testing.T, ctx context.Context, token string, method string, payload any) {
-	t.Helper()
-	_, _ = postGatewayConnectRaw(t, ctx, token, method, payload)
-}
-
-func postGatewayConnectRaw(t *testing.T, ctx context.Context, token string, method string, payload any) (string, int) {
-	t.Helper()
-	body, err := json.Marshal(payload)
-	if err != nil {
-		t.Fatalf("marshal gateway %s request: %v", method, err)
-	}
-
-	endpoint := gatewayLLMConnectEndpoint(t, method)
-
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
-	if err != nil {
-		t.Fatalf("build gateway %s request: %v", method, err)
-	}
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Connect-Protocol-Version", "1")
-	request.Header.Set("Authorization", "Bearer "+token)
-
-	response, err := newGatewayClient(t).Do(request)
-	if err != nil {
-		t.Fatalf("post gateway %s: %v", method, err)
-	}
-	defer response.Body.Close()
-
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("read gateway %s response: %v", method, err)
-	}
-	return strings.TrimSpace(string(responseBody)), response.StatusCode
-}
-
-func gatewayLLMConnectEndpoint(t *testing.T, method string) string {
-	t.Helper()
-	endpoint, err := url.JoinPath(gatewayBaseURL(t), llmGatewayServicePath, method)
-	if err != nil {
-		t.Fatalf("build gateway %s url: %v", method, err)
-	}
-	return endpoint
 }
 
 type llmProxyResponsesRequest struct {

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -98,44 +98,34 @@ func newUserID() string {
 	return uuid.New().String()
 }
 
-func createLLMProvider(t *testing.T, ctx context.Context, client llmv1.LLMServiceClient, endpoint, orgID string) *llmv1.LLMProvider {
+func createLLMProvider(t *testing.T, ctx context.Context, _ llmv1.LLMServiceClient, endpoint, orgID string) *llmv1.LLMProvider {
 	t.Helper()
-	return createLLMProviderWithProtocol(t, ctx, client, endpoint, orgID, llmv1.Protocol_PROTOCOL_RESPONSES)
+	return createLLMProviderWithProtocol(t, ctx, endpoint, orgID, llmv1.Protocol_PROTOCOL_RESPONSES)
 }
 
-func createLLMProviderWithProtocol(t *testing.T, ctx context.Context, client llmv1.LLMServiceClient, endpoint, orgID string, protocol llmv1.Protocol) *llmv1.LLMProvider {
+func createLLMProviderWithProtocol(t *testing.T, ctx context.Context, endpoint, orgID string, protocol llmv1.Protocol) *llmv1.LLMProvider {
 	t.Helper()
-	resp, err := client.CreateLLMProvider(ctx, &llmv1.CreateLLMProviderRequest{
-		Endpoint:       endpoint,
-		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
-		Token:          "test-token",
-		OrganizationId: orgID,
-		Protocol:       protocol,
-	})
+	provider, err := createGatewayLLMProviderResource(
+		t,
+		ctx,
+		gatewayAPIToken(t),
+		endpoint,
+		"AUTH_METHOD_BEARER",
+		"test-token",
+		orgID,
+		protocol,
+	)
 	if err != nil {
-		t.Fatalf("create llm provider: %v", err)
-	}
-	provider := resp.GetProvider()
-	if provider == nil || provider.GetMeta() == nil {
-		t.Fatal("create llm provider: nil response")
+		t.Fatalf("create llm provider through gateway: %v", err)
 	}
 	return provider
 }
 
-func createModel(t *testing.T, ctx context.Context, client llmv1.LLMServiceClient, name, providerID, remoteName, orgID string) *llmv1.Model {
+func createModel(t *testing.T, ctx context.Context, _ llmv1.LLMServiceClient, name, providerID, remoteName, orgID string) *llmv1.Model {
 	t.Helper()
-	resp, err := client.CreateModel(ctx, &llmv1.CreateModelRequest{
-		Name:           name,
-		LlmProviderId:  providerID,
-		RemoteName:     remoteName,
-		OrganizationId: orgID,
-	})
+	model, err := createGatewayLLMModelResource(t, ctx, gatewayAPIToken(t), name, orgID, providerID, remoteName)
 	if err != nil {
-		t.Fatalf("create model %q: %v", name, err)
-	}
-	model := resp.GetModel()
-	if model == nil || model.GetMeta() == nil {
-		t.Fatal("create model: nil response")
+		t.Fatalf("create model %q through gateway: %v", name, err)
 	}
 	return model
 }

--- a/suites/go-core/tests/pipeline_test.go
+++ b/suites/go-core/tests/pipeline_test.go
@@ -59,7 +59,7 @@ func runFullPipelineMessageResponseWithProtocol(t *testing.T, llmEndpoint, initI
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProviderWithProtocol(t, ctx, llmClient, llmEndpoint, orgID, protocol)
+	provider := createLLMProviderWithProtocol(t, ctx, llmEndpoint, orgID, protocol)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")


### PR DESCRIPTION
## Summary
- Route go-core LLM provider/model setup through the Gateway Connect API when `AGYN_API_TOKEN` is present.
- Keep the true E2E auth path intact by using bearer auth and Gateway identity propagation instead of internal LLM gRPC metadata injection.
- Make shared Gateway helpers available to the agents-orchestrator tagged tests.

Fixes agynio/agents#59

## Tests
- `go test ./...`
- `go test -tags "e2e svc_llm svc_llm_proxy" -run 'TestLLMGatewayConnectEndpointPath|TestLLMProxyURLDefaultUsesIngress|TestLLMProxyURLExplicitOverride' ./tests`
- `go vet ./...`

## Notes
- `go test -tags "e2e svc_agents_orchestrator" -run '^TestNoDuplicateWorkloads$' ./tests` was attempted locally and reached the expected environment boundary (`dial agents:50051: context deadline exceeded`) because the local Kubernetes E2E stack is not running in this workspace.