### PR TITLE
fix(go-core): include identity on LLM setup

### DIFF
--- a/suites/go-core/tests/agent_agyn_wait_test.go
+++ b/suites/go-core/tests/agent_agyn_wait_test.go
@@ -45,14 +45,14 @@ func TestAgentAgynCLIWaitToAnotherAgent(t *testing.T) {
 	threadsCtx := withIdentity(ctx, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointAgn, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointAgn, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
 
-	agentAModel := createModel(t, ctx, llmClient, "e2e-agyn-wait-agent-a-model-"+uuid.NewString(), providerID, "shell-agyn-thread-create-wait", orgID)
-	agentBModel := createModel(t, ctx, llmClient, "e2e-agyn-wait-agent-b-model-"+uuid.NewString(), providerID, "agyn-wait-agent-b-reply", orgID)
+	agentAModel := createModel(t, threadsCtx, llmClient, "e2e-agyn-wait-agent-a-model-"+uuid.NewString(), providerID, "shell-agyn-thread-create-wait", orgID)
+	agentBModel := createModel(t, threadsCtx, llmClient, "e2e-agyn-wait-agent-b-model-"+uuid.NewString(), providerID, "agyn-wait-agent-b-reply", orgID)
 
 	agentBNickname := "e2e-agyn-wait-b-fixed"
 	agentB := createAgentWithNickname(t, threadsCtx, agentsClient, "e2e-agyn-wait-agent-b-"+uuid.NewString(), agentBNickname, agentBModel.GetMeta().GetId(), orgID, agnInitImage)

--- a/suites/go-core/tests/dedup_test.go
+++ b/suites/go-core/tests/dedup_test.go
@@ -40,12 +40,12 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/dedup_test.go
+++ b/suites/go-core/tests/dedup_test.go
@@ -79,7 +79,7 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		agentCleanupCtx := withIdentity(cleanupCtx, agentID)
+		agentCleanupCtx := withAgentIdentity(cleanupCtx, agentID)
 		ackAllUnackedMessagesBestEffort(t, agentCleanupCtx, threadsClient, agentID)
 		ids, err := findWorkloadsByLabels(cleanupCtx, runnerClient, labels)
 		if err != nil {

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -181,12 +181,12 @@ func setupExposeTestWorkload(t *testing.T) exposeWorkloadFixture {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointAgn, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointAgn, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-expose-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-expose-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/gateway_helpers_test.go
+++ b/suites/go-core/tests/gateway_helpers_test.go
@@ -18,7 +18,6 @@ import (
 	usersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/users/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -148,7 +147,7 @@ func gatewayUserToken(t *testing.T) string {
 		t.Fatal("resolve user: identity id missing")
 	}
 
-	callCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("x-identity-id", identityID))
+	callCtx := withIdentity(ctx, identityID)
 	tokenResp, err := usersClient.CreateAPIToken(callCtx, &usersv1.CreateAPITokenRequest{
 		Name: fmt.Sprintf("e2e-gateway-token-%s", uuid.NewString()),
 	})

--- a/suites/go-core/tests/identity_constants_test.go
+++ b/suites/go-core/tests/identity_constants_test.go
@@ -3,3 +3,10 @@
 package tests
 
 const clusterAdminIdentityID = "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"
+
+const (
+	identityMetadataKey     = "x-identity-id"
+	identityTypeMetadataKey = "x-identity-type"
+	identityTypeUser        = "user"
+	identityTypeAgent       = "agent"
+)

--- a/suites/go-core/tests/identity_helpers_test.go
+++ b/suites/go-core/tests/identity_helpers_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func withIdentity(ctx context.Context, identityID string) context.Context {
-	md := metadata.New(map[string]string{"x-identity-id": identityID})
+	md := metadata.New(map[string]string{
+		"x-identity-id":   identityID,
+		"x-identity-type": "user",
+	})
 	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/suites/go-core/tests/identity_helpers_test.go
+++ b/suites/go-core/tests/identity_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_runners && !smoke
+//go:build e2e
 
 package tests
 
@@ -9,9 +9,17 @@ import (
 )
 
 func withIdentity(ctx context.Context, identityID string) context.Context {
+	return contextWithIdentity(ctx, identityID, identityTypeUser)
+}
+
+func withAgentIdentity(ctx context.Context, agentID string) context.Context {
+	return contextWithIdentity(ctx, agentID, identityTypeAgent)
+}
+
+func contextWithIdentity(ctx context.Context, identityID string, identityType string) context.Context {
 	md := metadata.New(map[string]string{
-		"x-identity-id":   identityID,
-		"x-identity-type": "user",
+		identityMetadataKey:     identityID,
+		identityTypeMetadataKey: identityType,
 	})
 	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/suites/go-core/tests/idle_test.go
+++ b/suites/go-core/tests/idle_test.go
@@ -66,7 +66,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	agentThreadsCtx := withIdentity(ctx, agentID)
+	agentThreadsCtx := withAgentIdentity(ctx, agentID)
 	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
 	agentInfoResp, err := agentsClient.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
 	if err != nil {

--- a/suites/go-core/tests/idle_test.go
+++ b/suites/go-core/tests/idle_test.go
@@ -49,12 +49,12 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/imagepull_test.go
+++ b/suites/go-core/tests/imagepull_test.go
@@ -53,12 +53,12 @@ func TestImagePullSecretAttachedToPod(t *testing.T) {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/mcp_test.go
+++ b/suites/go-core/tests/mcp_test.go
@@ -49,12 +49,12 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, llmEndpoint, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, llmEndpoint, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "mcp-tools-test", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "mcp-tools-test", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/multi_test.go
+++ b/suites/go-core/tests/multi_test.go
@@ -40,12 +40,12 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")
@@ -175,12 +175,12 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/organizations_test.go
+++ b/suites/go-core/tests/organizations_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
@@ -118,7 +117,7 @@ func listOrganizations(ctx context.Context, t *testing.T, client organizationsv1
 }
 
 func identityContext(ctx context.Context, identityID string) context.Context {
-	return metadata.NewOutgoingContext(ctx, metadata.Pairs("x-identity-id", identityID))
+	return withIdentity(ctx, identityID)
 }
 
 func hasID(items []*organizationsv1.Organization, id string) bool {

--- a/suites/go-core/tests/pipeline_test.go
+++ b/suites/go-core/tests/pipeline_test.go
@@ -59,12 +59,12 @@ func runFullPipelineMessageResponseWithProtocol(t *testing.T, llmEndpoint, initI
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProviderWithProtocol(t, ctx, llmEndpoint, orgID, protocol)
+	provider := createLLMProviderWithProtocol(t, threadsCtx, llmEndpoint, orgID, protocol)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/runners_helpers_test.go
+++ b/suites/go-core/tests/runners_helpers_test.go
@@ -11,7 +11,6 @@ import (
 	authorizationv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/authorization/v1"
 	runnersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runners/v1"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -22,11 +21,6 @@ const (
 	authorizationClusterRelation    = "cluster"
 	authorizationAdminRelation      = "admin"
 	authorizationGlobalCluster      = "cluster:global"
-
-	identityMetadataKey     = "x-identity-id"
-	identityTypeMetadataKey = "x-identity-type"
-	identityTypeUser        = "user"
-	identityTypeAgent       = "agent"
 
 	runnerContainerImage = "alpine:3.21"
 )
@@ -49,19 +43,12 @@ func newAuthorizationClient(t *testing.T) authorizationv1.AuthorizationServiceCl
 	return authorizationv1.NewAuthorizationServiceClient(conn)
 }
 
-func contextWithIdentity(ctx context.Context, identityID string, identityType string) context.Context {
-	return metadata.NewOutgoingContext(ctx, metadata.Pairs(
-		identityMetadataKey, identityID,
-		identityTypeMetadataKey, identityType,
-	))
-}
-
 func adminContext(ctx context.Context) context.Context {
 	return contextWithIdentity(ctx, clusterAdminIdentityID, identityTypeUser)
 }
 
 func agentContext(ctx context.Context, agentID string) context.Context {
-	return contextWithIdentity(ctx, agentID, identityTypeAgent)
+	return withAgentIdentity(ctx, agentID)
 }
 
 func ensureClusterAdmin(t *testing.T, ctx context.Context, authzClient authorizationv1.AuthorizationServiceClient) {

--- a/suites/go-core/tests/setup_test.go
+++ b/suites/go-core/tests/setup_test.go
@@ -12,18 +12,12 @@ import (
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	usersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/users/v1"
 	"github.com/google/uuid"
-	"google.golang.org/grpc/metadata"
 )
 
 const (
 	setupTimeout = 30 * time.Second
 	apiTokenName = "e2e-orchestrator"
 )
-
-func withIdentity(ctx context.Context, identityID string) context.Context {
-	md := metadata.New(map[string]string{"x-identity-id": identityID})
-	return metadata.NewOutgoingContext(ctx, md)
-}
 
 func resolveOrCreateUser(t *testing.T, ctx context.Context, client usersv1.UsersServiceClient) string {
 	t.Helper()

--- a/suites/go-core/tests/start_test.go
+++ b/suites/go-core/tests/start_test.go
@@ -40,12 +40,12 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/threads_send_test.go
+++ b/suites/go-core/tests/threads_send_test.go
@@ -41,12 +41,12 @@ func TestThreadsSendShell(t *testing.T) {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointAgn, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointAgn, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "shell-threads-send", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "shell-threads-send", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/workload_start_retry_policy_test.go
+++ b/suites/go-core/tests/workload_start_retry_policy_test.go
@@ -63,12 +63,12 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")


### PR DESCRIPTION
## Summary
- Add `x-identity-type: user` to the go-core `withIdentity` helper.
- Pass identity-bearing contexts into direct LLM setup calls for providers and models.
- Audit go-core LLM setup call sites so direct LLM service setup no longer uses a plain context.

Closes #139

## Test & Lint Summary
- `go vet -tags "e2e smoke" ./tests/...` from `suites/go-core`: passed with no errors.
- `go test -tags "e2e smoke" ./tests/... -run '^$'` from `suites/go-core`: 0 passed / 0 failed / 0 skipped (compile-only; no tests selected).
- `go test -tags "e2e smoke" ./tests/...` from `suites/go-core`: unable to complete locally because the suite requires live cluster services (`agents:50051`, `k8s-runner:50051`, etc.); compile and vet pass locally.