### PR TITLE
fix(actions): pin run-tests checkout

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -17,10 +17,6 @@ inputs:
   provider-binary:
     description: Optional path to a Terraform provider binary in the caller workspace.
     required: false
-  ref:
-    description: agynio/e2e ref to check out.
-    required: false
-    default: main
 runs:
   using: composite
   steps:
@@ -28,7 +24,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: agynio/e2e
-        ref: ${{ inputs.ref }}
+        ref: main
         path: e2e
 
     - name: Stage provider binary

--- a/.github/workflows/agn-cli-e2e.yml
+++ b/.github/workflows/agn-cli-e2e.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Run go-agn-cli suite
         uses: ./.github/actions/run-tests
         with:
-          ref: ${{ github.sha }}
           tag: svc_agn_cli
           include_smoke: false
           agn-binary: agn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,5 @@ jobs:
           E2E_SUITES: playwright
           E2E_PLAYWRIGHT_TEST_ARGS: test/e2e/organization-platform-usage.spec.ts
         with:
-          ref: ${{ github.sha }}
           tag: svc_metering
           include_smoke: false


### PR DESCRIPTION
## Summary
- Remove the `ref` input from the `run-tests` composite action.
- Always checkout `agynio/e2e` at `main` inside the action.
- Remove local workflow callers' now-unsupported `ref` inputs.

Fixes #142.

## Test & lint summary
- `node -e "const fs=require('fs'); for (const f of process.argv.slice(1)) { const s=fs.readFileSync(f,'utf8'); if (s.includes('\\t')) throw new Error(f + ': contains tab'); for (const [i,l] of s.split(/\\r?\\n/).entries()) { if (/^ *\\S/.test(l) && l.match(/^ */)[0].length % 2) throw new Error(f + ':' + (i+1) + ': odd indentation'); } console.log('ok ' + f); }" .github/actions/run-tests/action.yml .github/workflows/e2e.yml .github/workflows/agn-cli-e2e.yml` — passed for 3 YAML files.
- `rg -n "inputs\\.ref|ref: \\$\\{\\{ github\\.sha \\}\\}|agynio/e2e ref|ref to check out" .github README.md scripts suites devspace.yaml` — passed; 0 stale references found.
- `git diff --check` — passed with no whitespace errors.