### PR TITLE
fix(go-core): align thread participants

### DIFF
--- a/suites/go-core/tests/dedup_test.go
+++ b/suites/go-core/tests/dedup_test.go
@@ -38,15 +38,25 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
-	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", gatewayToken)
+	var threadID string
+	t.Cleanup(func() {
+		if threadID != "" {
+			archiveThread(t, threadsCtx, threadsClient, threadID)
+		}
+		deleteAgent(t, threadsCtx, agentsClient, agentID)
+	})
+	agentEnv := createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", gatewayToken)
+	agentEnvID := agentEnv.GetMeta().GetId()
+	if agentEnvID == "" {
+		t.Fatal("create agent env: missing id")
+	}
+	t.Cleanup(func() { deleteAgentEnv(t, threadsCtx, agentsClient, agentEnvID) })
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
-	threadID := thread.GetId()
+	threadID = thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
 	for i := 1; i <= 3; i++ {
 		sendMessage(t, threadsCtx, threadsClient, threadID, identityID, fmt.Sprintf("msg %d", i))

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -227,6 +227,14 @@ func createAgentEnv(t *testing.T, ctx context.Context, client agentsv1.AgentsSer
 	return env
 }
 
+func deleteAgentEnv(t *testing.T, ctx context.Context, client agentsv1.AgentsServiceClient, envID string) {
+	t.Helper()
+	_, err := client.DeleteEnv(ctx, &agentsv1.DeleteEnvRequest{Id: envID})
+	if err != nil {
+		t.Logf("cleanup: delete agent env %s: %v", envID, err)
+	}
+}
+
 func createImagePullSecret(
 	t *testing.T,
 	ctx context.Context,


### PR DESCRIPTION
## Summary
- Fixes #145 by keeping `TestNoDuplicateWorkloads` cleanup robust while allowing E2E to exercise the fixed threads service behavior from agynio/threads#36.
- Reverted the `createThread` helper compatibility/filtering workaround so it now matches main behavior and passes `participant_ids` through unchanged.
- Keeps cleanup hardening by deleting the agent env and archiving the thread before deleting the agent, avoiding FK cleanup failures after early test errors.

## Tests
- `go test ./...`
- `go vet ./...`
- `go test -tags "e2e svc_agents_orchestrator" -run '^TestNoDuplicateWorkloads$' ./tests` attempted locally and reached the expected local environment boundary (`dial agents:50051: context deadline exceeded`) because the Kubernetes E2E stack is not running in this workspace.