### PR TITLE
fix(go-core): reuse gateway model in start e2e

### DIFF
--- a/suites/go-core/tests/start_test.go
+++ b/suites/go-core/tests/start_test.go
@@ -9,11 +9,8 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
-	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/threads/v1"
-	usersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/users/v1"
 	"github.com/google/uuid"
 )
 
@@ -24,47 +21,42 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
-	usersConn := dialGRPC(t, usersAddr)
-	orgsConn := dialGRPC(t, orgsAddr)
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
-	usersClient := usersv1.NewUsersServiceClient(usersConn)
-	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
-	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	gatewayToken := gatewayAPIToken(t)
+	gatewayIdentity := fetchGatewayIdentity(t, gatewayToken)
+	identityID := gatewayIdentity.IdentityID
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
-	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
-
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
-	providerID := provider.GetMeta().GetId()
-	if providerID == "" {
-		t.Fatal("create llm provider: missing id")
-	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
-	modelID := model.GetMeta().GetId()
-	if modelID == "" {
-		t.Fatal("create model: missing id")
-	}
+	orgID := gatewayOrganizationID(t)
+	modelID := gatewayModelID(t)
 
 	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-test-agent-start-%s", uuid.NewString()), modelID, orgID, codexInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, threadsCtx, agentsClient, agentID) })
-	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	var threadID string
+	t.Cleanup(func() {
+		if threadID != "" {
+			archiveThread(t, threadsCtx, threadsClient, threadID)
+		}
+		deleteAgent(t, threadsCtx, agentsClient, agentID)
+	})
+	agentEnv := createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", gatewayToken)
+	agentEnvID := agentEnv.GetMeta().GetId()
+	if agentEnvID == "" {
+		t.Fatal("create agent env: missing id")
+	}
+	t.Cleanup(func() { deleteAgentEnv(t, threadsCtx, agentsClient, agentEnvID) })
 
 	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
-	threadID := thread.GetId()
+	threadID = thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
 	_ = sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "e2e test message")
 


### PR DESCRIPTION
## Summary
- Fixes #147 by updating `TestWorkloadStartsOnUnackedMessage` to reuse the workflow-provisioned `AGYN_MODEL_ID` instead of creating an LLM provider/model in-test.
- Uses the workflow Gateway token identity and `AGYN_ORGANIZATION_ID` so model, token, agent, and thread scope stay consistent.
- Passes the workflow `AGYN_API_TOKEN` to the agent as `LLM_API_TOKEN`, matching the pre-provisioned model.
- Keeps cleanup robust by deleting the agent env and archiving the thread before deleting the agent.

## Tests
- `go test ./...`
- `go vet ./...`
- `go test -tags "e2e svc_agents_orchestrator" -run '^TestWorkloadStartsOnUnackedMessage$' ./tests` attempted locally and reached the expected local environment boundary (`dial agents:50051: context deadline exceeded`) because the Kubernetes E2E stack is not running in this workspace.