### PR TITLE
fix(e2e): unblock gateway and chat traces

### DIFF
--- a/suites/go-core/tests/agent_agyn_wait_test.go
+++ b/suites/go-core/tests/agent_agyn_wait_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/threads/v1"
@@ -32,27 +31,26 @@ func TestAgentAgynCLIWaitToAnotherAgent(t *testing.T) {
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 	usersConn := dialGRPC(t, usersAddr)
 	orgsConn := dialGRPC(t, orgsAddr)
-	llmConn := dialGRPC(t, llmAddr)
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointAgn, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointAgn, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
 
-	agentAModel := createModel(t, threadsCtx, llmClient, "e2e-agyn-wait-agent-a-model-"+uuid.NewString(), providerID, "shell-agyn-thread-create-wait", orgID)
-	agentBModel := createModel(t, threadsCtx, llmClient, "e2e-agyn-wait-agent-b-model-"+uuid.NewString(), providerID, "agyn-wait-agent-b-reply", orgID)
+	agentAModel := createModel(t, threadsCtx, token, "e2e-agyn-wait-agent-a-model-"+uuid.NewString(), providerID, "shell-agyn-thread-create-wait", orgID)
+	agentBModel := createModel(t, threadsCtx, token, "e2e-agyn-wait-agent-b-model-"+uuid.NewString(), providerID, "agyn-wait-agent-b-reply", orgID)
 
 	agentBNickname := "e2e-agyn-wait-b-fixed"
 	agentB := createAgentWithNickname(t, threadsCtx, agentsClient, "e2e-agyn-wait-agent-b-"+uuid.NewString(), agentBNickname, agentBModel.GetMeta().GetId(), orgID, agnInitImage)

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/threads/v1"
@@ -169,8 +168,6 @@ func setupExposeTestWorkload(t *testing.T) exposeWorkloadFixture {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
@@ -178,15 +175,15 @@ func setupExposeTestWorkload(t *testing.T) exposeWorkloadFixture {
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointAgn, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointAgn, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-expose-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-expose-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/idle_test.go
+++ b/suites/go-core/tests/idle_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runners/v1"
@@ -37,8 +36,6 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
@@ -46,15 +43,15 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/imagepull_test.go
+++ b/suites/go-core/tests/imagepull_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	secretsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/secrets/v1"
@@ -41,8 +40,6 @@ func TestImagePullSecretAttachedToPod(t *testing.T) {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
@@ -50,15 +47,15 @@ func TestImagePullSecretAttachedToPod(t *testing.T) {
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/llm_proxy_test.go
+++ b/suites/go-core/tests/llm_proxy_test.go
@@ -68,8 +68,8 @@ func TestLLMProxyGatewayCreatedModel(t *testing.T) {
 	authzClient := newLLMProxyAuthorizationClient(t)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
-	apiToken := createAPIToken(t, ctx, usersClient, identityID)
 	organizationID := createTestOrganization(t, ctx, orgsClient, identityID)
+	apiToken := createAPIToken(t, ctx, usersClient, identityID)
 
 	providerID, err := createGatewayLLMProvider(t, ctx, apiToken, organizationID)
 	if err != nil {

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -98,17 +98,17 @@ func newUserID() string {
 	return uuid.New().String()
 }
 
-func createLLMProvider(t *testing.T, ctx context.Context, _ llmv1.LLMServiceClient, endpoint, orgID string) *llmv1.LLMProvider {
+func createLLMProvider(t *testing.T, ctx context.Context, token string, endpoint, orgID string) *llmv1.LLMProvider {
 	t.Helper()
-	return createLLMProviderWithProtocol(t, ctx, endpoint, orgID, llmv1.Protocol_PROTOCOL_RESPONSES)
+	return createLLMProviderWithProtocol(t, ctx, token, endpoint, orgID, llmv1.Protocol_PROTOCOL_RESPONSES)
 }
 
-func createLLMProviderWithProtocol(t *testing.T, ctx context.Context, endpoint, orgID string, protocol llmv1.Protocol) *llmv1.LLMProvider {
+func createLLMProviderWithProtocol(t *testing.T, ctx context.Context, token, endpoint, orgID string, protocol llmv1.Protocol) *llmv1.LLMProvider {
 	t.Helper()
 	provider, err := createGatewayLLMProviderResource(
 		t,
 		ctx,
-		gatewayAPIToken(t),
+		token,
 		endpoint,
 		"AUTH_METHOD_BEARER",
 		"test-token",
@@ -121,9 +121,9 @@ func createLLMProviderWithProtocol(t *testing.T, ctx context.Context, endpoint, 
 	return provider
 }
 
-func createModel(t *testing.T, ctx context.Context, _ llmv1.LLMServiceClient, name, providerID, remoteName, orgID string) *llmv1.Model {
+func createModel(t *testing.T, ctx context.Context, token, name, providerID, remoteName, orgID string) *llmv1.Model {
 	t.Helper()
-	model, err := createGatewayLLMModelResource(t, ctx, gatewayAPIToken(t), name, orgID, providerID, remoteName)
+	model, err := createGatewayLLMModelResource(t, ctx, token, name, orgID, providerID, remoteName)
 	if err != nil {
 		t.Fatalf("create model %q through gateway: %v", name, err)
 	}

--- a/suites/go-core/tests/mcp_test.go
+++ b/suites/go-core/tests/mcp_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/threads/v1"
@@ -38,23 +37,21 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, llmEndpoint, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, llmEndpoint, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "mcp-tools-test", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "mcp-tools-test", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/multi_test.go
+++ b/suites/go-core/tests/multi_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/threads/v1"
@@ -29,23 +28,21 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")
@@ -164,23 +161,21 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/pipeline_test.go
+++ b/suites/go-core/tests/pipeline_test.go
@@ -48,23 +48,21 @@ func runFullPipelineMessageResponseWithProtocol(t *testing.T, llmEndpoint, initI
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProviderWithProtocol(t, threadsCtx, llmEndpoint, orgID, protocol)
+	provider := createLLMProviderWithProtocol(t, threadsCtx, token, llmEndpoint, orgID, protocol)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/start_test.go
+++ b/suites/go-core/tests/start_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/threads/v1"
@@ -29,23 +28,21 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/threads_send_test.go
+++ b/suites/go-core/tests/threads_send_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/threads/v1"
@@ -30,23 +29,21 @@ func TestThreadsSendShell(t *testing.T) {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointAgn, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointAgn, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "shell-threads-send", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "shell-threads-send", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/go-core/tests/workload_start_retry_policy_test.go
+++ b/suites/go-core/tests/workload_start_retry_policy_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/agents/v1"
-	llmv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/e2e/suites/go-core/.gen/go/agynio/api/runners/v1"
@@ -51,8 +50,6 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
-	llmConn := dialGRPC(t, llmAddr)
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
@@ -60,15 +57,15 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	threadsCtx := withIdentity(ctx, identityID)
-	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+	token := createAPIToken(t, ctx, usersClient, identityID)
 
-	provider := createLLMProvider(t, threadsCtx, llmClient, testLLMEndpointCodex, orgID)
+	provider := createLLMProvider(t, threadsCtx, token, testLLMEndpointCodex, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")
 	}
-	model := createModel(t, threadsCtx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	model := createModel(t, threadsCtx, token, "e2e-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
 	modelID := model.GetMeta().GetId()
 	if modelID == "" {
 		t.Fatal("create model: missing id")

--- a/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
@@ -92,8 +92,10 @@ async function openTraceFromChat(
     await callbackPromise;
   }
 
-  const runUrlPattern = new RegExp(`/${params.organizationId}/runs/[0-9a-f]{32}(\\?.*)?$`);
-  await expect(tracePage).toHaveURL(runUrlPattern, { timeout: 120000 });
+  const messageUrlPattern = new RegExp(`/message/${params.messageId}(\\?.*)?$`);
+  await expect(tracePage).toHaveURL(messageUrlPattern, { timeout: 120000 });
+  const openedTraceUrl = new URL(tracePage.url());
+  expect(openedTraceUrl.searchParams.get('orgId')).toBe(params.organizationId);
 
   await expect(tracePage.getByTestId('run-summary-status')).toContainText(/finished/i, { timeout: 120000 });
 


### PR DESCRIPTION
## Summary
- Use the per-test organization owner API token for Gateway-backed LLM provider/model setup instead of the bootstrap gateway token.
- Apply the same post-organization token ordering to the LLM proxy Gateway-created model test path.
- Remove now-unused direct LLM service clients from those setup paths.
- Update chat trace-link E2E to expect the current tracing message deep-link URL (`/message/<messageId>?orgId=<orgId>`) while still asserting the run timeline renders.

Closes #153.

## Test & lint summary
- `CGO_ENABLED=0 go test -tags "e2e smoke" ./tests/... -run '^$'` — passed compile-only; 0 passed / 0 failed / 0 skipped (`tests` reported no tests to run, `tracecanary` has no test files).
- `CGO_ENABLED=0 go vet -tags "e2e smoke" ./tests/...` — passed with no errors.
- `npm ci --no-audit --no-fund` — passed for `suites/playwright-chat-app`.
- `npx buf generate` — passed for `suites/playwright-chat-app`.
- `npx tsc --noEmit` — passed for `suites/playwright-chat-app`.
- `git diff --check` — passed with no whitespace errors.