### PR TITLE
test(go-core): authenticate idle diagnostics

### DIFF
--- a/suites/go-core/tests/idle_test.go
+++ b/suites/go-core/tests/idle_test.go
@@ -139,7 +139,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	idleCtx, idleCancel := context.WithTimeout(ctx, idleStopTimeout)
 	defer idleCancel()
 	if err := pollUntil(idleCtx, pollInterval, func(ctx context.Context) error {
-		logRunnersWorkloadState(t, threadsCtx, runnersClient, workloadID)
+		logRunnersWorkloadState(t, withIdentity(ctx, identityID), runnersClient, workloadID)
 		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)
 		if err != nil {
 			return err

--- a/suites/go-core/tests/idle_test.go
+++ b/suites/go-core/tests/idle_test.go
@@ -139,7 +139,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	idleCtx, idleCancel := context.WithTimeout(ctx, idleStopTimeout)
 	defer idleCancel()
 	if err := pollUntil(idleCtx, pollInterval, func(ctx context.Context) error {
-		logRunnersWorkloadState(t, ctx, runnersClient, workloadID)
+		logRunnersWorkloadState(t, threadsCtx, runnersClient, workloadID)
 		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)
 		if err != nil {
 			return err
@@ -151,7 +151,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	}); err != nil {
 		diagCtx, cancelDiag := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancelDiag()
-		logRunnersWorkloadState(t, diagCtx, runnersClient, workloadID)
+		logRunnersWorkloadState(t, withIdentity(diagCtx, identityID), runnersClient, workloadID)
 		t.Fatalf("wait for workload stop: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Authenticates the idle-timeout diagnostics-only `runners.GetWorkload` calls with the workflow user identity.
- Keeps the actual workload polling path unchanged; this only prevents diagnostic logging from emitting unauthenticated runners errors.

## Investigation
- agents-orchestrator E2E run 26468441507 showed `idle_test.go:142` direct diagnostics calling runners with a context that had no identity metadata.
- This is separate from the expose CLI path, which is fixed in agynio/gateway#186.

## Testing
- `buf generate` (local compile prep only; generated outputs were not committed)
- `go test -tags 'e2e svc_agents_orchestrator' ./tests -run '^$' -count=1` (passed: 0 tests run, failed: 0, skipped: 0)
- `go vet -tags 'e2e svc_agents_orchestrator' ./tests` (lint passed with no errors)

Full runtime `TestWorkloadStopsAfterIdleTimeout` requires the E2E cluster services and was not run locally in this isolated workspace.