### PR TITLE
fix(chat-app): wait for trace run redirect

### DIFF
--- a/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
@@ -50,7 +50,21 @@ async function waitForRunPageFromMessageDeepLink(
   params: { messageId: string; organizationId: string; runUrlPattern: RegExp; timeoutMs: number },
 ): Promise<void> {
   const messageUrlPattern = new RegExp(`/message/${params.messageId}(\\?.*)?$`);
-  await expect(page).toHaveURL(messageUrlPattern, { timeout: params.timeoutMs });
+
+  const initialUrl = page.url();
+  if (params.runUrlPattern.test(initialUrl)) {
+    return;
+  }
+
+  if (!messageUrlPattern.test(initialUrl)) {
+    await expect(page).toHaveURL((url) => messageUrlPattern.test(url.href) || params.runUrlPattern.test(url.href), {
+      timeout: params.timeoutMs,
+    });
+
+    if (params.runUrlPattern.test(page.url())) {
+      return;
+    }
+  }
 
   const openedTraceUrl = new URL(page.url());
   expect(openedTraceUrl.searchParams.get('orgId')).toBe(params.organizationId);

--- a/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
@@ -17,6 +17,8 @@ const CLAUDE_TEST_LLM_ENDPOINT =
   process.env.E2E_TEST_LLM_ENDPOINT_CLAUDE ?? 'https://testllm.dev/v1/org/agynio/suite/claude/messages';
 const CLAUDE_INIT_IMAGE = process.env.CLAUDE_INIT_IMAGE ?? 'ghcr.io/agynio/agent-init-claude:latest';
 const CLAUDE_PROTOCOL = 'PROTOCOL_ANTHROPIC_MESSAGES';
+const MESSAGE_DEEP_LINK_RESOLUTION_TIMEOUT_MS = 180000;
+const MESSAGE_DEEP_LINK_POLL_INTERVAL_MS = 5000;
 
 function isTimeoutError(error: unknown): error is Error {
   return error instanceof Error && error.name === 'TimeoutError';
@@ -45,18 +47,36 @@ const TRACE_SCENARIOS: TraceScenario[] = [
 
 async function waitForRunPageFromMessageDeepLink(
   page: Page,
-  runUrlPattern: RegExp,
-  timeoutMs: number,
+  params: { messageId: string; organizationId: string; runUrlPattern: RegExp; timeoutMs: number },
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
+  const messageUrlPattern = new RegExp(`/message/${params.messageId}(\\?.*)?$`);
+  await expect(page).toHaveURL(messageUrlPattern, { timeout: params.timeoutMs });
+
+  const openedTraceUrl = new URL(page.url());
+  expect(openedTraceUrl.searchParams.get('orgId')).toBe(params.organizationId);
+
+  const resolvingMessage = page.getByText('Resolving message...');
+  const noRunMessage = page.getByText('No run found for message.');
+  const retryButton = page.getByRole('button', { name: 'Retry' });
+
+  const deadline = Date.now() + params.timeoutMs;
 
   while (Date.now() < deadline) {
-    if (runUrlPattern.test(page.url())) {
+    if (params.runUrlPattern.test(page.url())) {
       return;
     }
 
-    const retryButton = page.getByRole('button', { name: 'Retry' });
-    if (await retryButton.isVisible({ timeout: 500 })) {
+    if (!messageUrlPattern.test(page.url())) {
+      throw new Error(`Trace message deep link navigated to an unexpected URL: ${page.url()}`);
+    }
+
+    if (await resolvingMessage.isVisible({ timeout: 500 })) {
+      await expect(resolvingMessage).toBeVisible();
+    }
+
+    if (await noRunMessage.isVisible({ timeout: 500 })) {
+      await expect(noRunMessage).toBeVisible();
+      await expect(retryButton).toBeVisible({ timeout: 5000 });
       await retryButton.click();
     }
 
@@ -65,7 +85,9 @@ async function waitForRunPageFromMessageDeepLink(
       break;
     }
 
-    await page.waitForURL(runUrlPattern, { timeout: Math.min(5000, remainingMs) }).catch((error) => {
+    await page.waitForURL(params.runUrlPattern, {
+      timeout: Math.min(MESSAGE_DEEP_LINK_POLL_INTERVAL_MS, remainingMs),
+    }).catch((error) => {
       if (isTimeoutError(error)) {
         return;
       }
@@ -120,18 +142,18 @@ async function openTraceFromChat(
     }
     throw error;
   });
-  const completed = await completeOidcLogin(tracePage, { timeoutMs: 10000 });
+  const completed = await completeOidcLogin(tracePage, { timeoutMs: 60000 });
   if (completed) {
     await callbackPromise;
   }
 
-  const messageUrlPattern = new RegExp(`/message/${params.messageId}(\\?.*)?$`);
-  await expect(tracePage).toHaveURL(messageUrlPattern, { timeout: 120000 });
-  const openedTraceUrl = new URL(tracePage.url());
-  expect(openedTraceUrl.searchParams.get('orgId')).toBe(params.organizationId);
-
   const runUrlPattern = new RegExp(`/${params.organizationId}/runs/[0-9a-f]{32}(\\?.*)?$`);
-  await waitForRunPageFromMessageDeepLink(tracePage, runUrlPattern, 180000);
+  await waitForRunPageFromMessageDeepLink(tracePage, {
+    messageId: params.messageId,
+    organizationId: params.organizationId,
+    runUrlPattern,
+    timeoutMs: MESSAGE_DEEP_LINK_RESOLUTION_TIMEOUT_MS,
+  });
 
   await expect(tracePage).toHaveURL(runUrlPattern);
   await expect(tracePage.getByTestId('run-summary-status')).toContainText(/finished/i, { timeout: 120000 });


### PR DESCRIPTION
## Summary
- Updates the chat-app trace-link E2E to treat `/message/<messageId>?orgId=<orgId>` as a transitional tracing deeplink.
- Waits up to 180s for the tracing app to redirect to `/<orgId>/runs/<runId>`.
- Handles the tracing-app empty state by asserting `No run found for message.`, clicking `Retry`, and continuing to wait.
- Keeps the success condition on the run page widgets/events instead of the message page.

Related to chat-app PR #104.

## Test & lint summary
- `npm ci --no-fund --no-audit`: dependencies installed successfully.
- `npx buf generate`: generated protobuf sources successfully.
- `npx tsc --noEmit`: type/lint check passed with no errors.
- `CI=true E2E_BASE_URL=https://chat.agyn.dev npx playwright test test/e2e/chat-trace-link.spec.ts --list`: 2 tests discovered, 0 failed, 0 skipped.
- Full targeted Playwright execution against `https://chat.agyn.dev` was attempted after installing browsers, but the currently deployed tracing app did not resolve the generated chat message IDs to runs within 180s, so this PR preserves the requested behavior for rerun with chat-app PR #104.