### PR TITLE
fix(go-core): add timing watchdog

### DIFF
--- a/suites/go-core/internal/go-test-breadcrumbs/main.go
+++ b/suites/go-core/internal/go-test-breadcrumbs/main.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testEvent struct {
+	Time    time.Time `json:"Time"`
+	Action  string    `json:"Action"`
+	Package string    `json:"Package"`
+	Test    string    `json:"Test"`
+	Elapsed float64   `json:"Elapsed"`
+	Output  string    `json:"Output"`
+}
+
+type activeTest struct {
+	Package string
+	Test    string
+	Started time.Time
+}
+
+type breadcrumbLogger struct {
+	now          func() time.Time
+	started      time.Time
+	active       map[string]activeTest
+	seenPackages map[string]struct{}
+	out          io.Writer
+	err          io.Writer
+}
+
+func newBreadcrumbLogger(out, err io.Writer, now func() time.Time) *breadcrumbLogger {
+	started := now()
+	return &breadcrumbLogger{
+		now:          now,
+		started:      started,
+		active:       make(map[string]activeTest),
+		seenPackages: make(map[string]struct{}),
+		out:          out,
+		err:          err,
+	}
+}
+
+func main() {
+	interval := flag.Duration("interval", 30*time.Second, "active-test breadcrumb interval")
+	goTestTimeout := flag.String("timeout", "", "go test package timeout for log context")
+	flag.Parse()
+
+	logger := newBreadcrumbLogger(os.Stdout, os.Stderr, time.Now)
+	logger.logSuiteStart(*goTestTimeout, *interval)
+
+	if err := logger.run(os.Stdin, *interval); err != nil {
+		fmt.Fprintf(os.Stderr, "[go-test-timing] error=%q\n", err.Error())
+		os.Exit(1)
+	}
+}
+
+func (l *breadcrumbLogger) run(input io.Reader, interval time.Duration) error {
+	events := make(chan testEvent)
+	done := make(chan error, 1)
+
+	go func() {
+		defer close(events)
+		done <- scanEvents(input, events, l.out)
+	}()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				l.logActive("finish")
+				return <-done
+			}
+			l.handle(event)
+		case <-ticker.C:
+			l.logActive("running")
+		}
+	}
+}
+
+func scanEvents(input io.Reader, events chan<- testEvent, out io.Writer) error {
+	scanner := bufio.NewScanner(input)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		var event testEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			fmt.Fprintln(out, line)
+			continue
+		}
+		events <- event
+	}
+	return scanner.Err()
+}
+
+func (l *breadcrumbLogger) handle(event testEvent) {
+	if event.Output != "" {
+		fmt.Fprint(l.out, event.Output)
+	}
+	if event.Package != "" {
+		if _, ok := l.seenPackages[event.Package]; !ok {
+			l.seenPackages[event.Package] = struct{}{}
+			l.logf("package_start package=%s suite_elapsed=%s", event.Package, l.sinceStart())
+		}
+	}
+	if event.Test == "" {
+		return
+	}
+
+	switch event.Action {
+	case "run", "cont":
+		l.active[eventKey(event.Package, event.Test)] = activeTest{
+			Package: event.Package,
+			Test:    event.Test,
+			Started: l.eventTime(event),
+		}
+		l.logf("test_start package=%s test=%s suite_elapsed=%s", event.Package, event.Test, l.sinceStart())
+	case "pass", "fail", "skip":
+		key := eventKey(event.Package, event.Test)
+		elapsed := l.elapsedFor(event, key)
+		delete(l.active, key)
+		l.logf("test_%s package=%s test=%s elapsed=%s suite_elapsed=%s", event.Action, event.Package, event.Test, elapsed, l.sinceStart())
+	}
+}
+
+func (l *breadcrumbLogger) logSuiteStart(timeout string, interval time.Duration) {
+	if strings.TrimSpace(timeout) == "" {
+		timeout = "go-default"
+	}
+	l.logf("suite_start timeout=%s interval=%s", timeout, interval)
+}
+
+func (l *breadcrumbLogger) logActive(state string) {
+	if len(l.active) == 0 {
+		l.logf("suite_%s active=0 suite_elapsed=%s", state, l.sinceStart())
+		return
+	}
+
+	entries := make([]activeTest, 0, len(l.active))
+	for _, entry := range l.active {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Package == entries[j].Package {
+			return entries[i].Test < entries[j].Test
+		}
+		return entries[i].Package < entries[j].Package
+	})
+	for _, entry := range entries {
+		l.logf(
+			"suite_%s active=%d package=%s test=%s elapsed=%s suite_elapsed=%s",
+			state,
+			len(entries),
+			entry.Package,
+			entry.Test,
+			l.now().Sub(entry.Started).Round(time.Millisecond),
+			l.sinceStart(),
+		)
+	}
+}
+
+func (l *breadcrumbLogger) elapsedFor(event testEvent, key string) time.Duration {
+	if event.Elapsed > 0 {
+		return time.Duration(event.Elapsed * float64(time.Second)).Round(time.Millisecond)
+	}
+	active, ok := l.active[key]
+	if !ok {
+		return 0
+	}
+	return l.eventTime(event).Sub(active.Started).Round(time.Millisecond)
+}
+
+func (l *breadcrumbLogger) eventTime(event testEvent) time.Time {
+	if !event.Time.IsZero() {
+		return event.Time
+	}
+	return l.now()
+}
+
+func (l *breadcrumbLogger) sinceStart() time.Duration {
+	return l.now().Sub(l.started).Round(time.Millisecond)
+}
+
+func (l *breadcrumbLogger) logf(format string, args ...any) {
+	fmt.Fprintf(l.err, "[go-test-timing] "+format+"\n", args...)
+}
+
+func eventKey(packageName, testName string) string {
+	return packageName + "\x00" + testName
+}

--- a/suites/go-core/internal/go-test-breadcrumbs/main_test.go
+++ b/suites/go-core/internal/go-test-breadcrumbs/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBreadcrumbLoggerReportsTestDurations(t *testing.T) {
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	now := time.Date(2026, 5, 28, 14, 0, 0, 0, time.UTC)
+	logger := newBreadcrumbLogger(&out, &stderr, func() time.Time { return now })
+
+	logger.handle(testEvent{
+		Time:    now,
+		Action:  "run",
+		Package: "github.com/agynio/e2e/suites/go-core/tests",
+		Test:    "TestExample",
+	})
+	now = now.Add(3 * time.Second)
+	logger.handle(testEvent{
+		Time:    now,
+		Action:  "pass",
+		Package: "github.com/agynio/e2e/suites/go-core/tests",
+		Test:    "TestExample",
+		Elapsed: 3,
+	})
+
+	logs := stderr.String()
+	for _, expected := range []string{
+		"package_start package=github.com/agynio/e2e/suites/go-core/tests",
+		"test_start package=github.com/agynio/e2e/suites/go-core/tests test=TestExample",
+		"test_pass package=github.com/agynio/e2e/suites/go-core/tests test=TestExample elapsed=3s",
+	} {
+		if !strings.Contains(logs, expected) {
+			t.Fatalf("missing log %q in:\n%s", expected, logs)
+		}
+	}
+}
+
+func TestScanEventsPassesThroughPlainOutput(t *testing.T) {
+	input := strings.NewReader("plain line\n{\"Action\":\"run\",\"Package\":\"pkg\",\"Test\":\"TestOne\"}\n")
+	var out bytes.Buffer
+	events := make(chan testEvent, 1)
+
+	if err := scanEvents(input, events, &out); err != nil {
+		t.Fatalf("scan events: %v", err)
+	}
+	close(events)
+
+	if got := out.String(); got != "plain line\n" {
+		t.Fatalf("plain output mismatch: got %q", got)
+	}
+	event := <-events
+	if event.Package != "pkg" || event.Test != "TestOne" || event.Action != "run" {
+		t.Fatalf("event mismatch: %#v", event)
+	}
+}

--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -46,14 +46,24 @@ run: |
 
   tmp_json=$(mktemp)
   set +e
-  go_test_args=(-count=1 -tags "${tag_args}")
+  # The go-core suite can legitimately run tests with 8m per-test contexts.
+  # Keep a package-level watchdog, but make it larger than any single test so
+  # CI fails on true hangs instead of exhausting Go's implicit 10m default.
+  go_test_timeout="${E2E_GO_TEST_TIMEOUT:-25m}"
+  go_test_args=(-count=1 -timeout "${go_test_timeout}" -tags "${tag_args}" -v)
   if [ -n "${E2E_GO_TEST_RUN:-}" ]; then
     go_test_args+=(-run "${E2E_GO_TEST_RUN}")
   fi
   go_test_args+=(-json ./tests/...)
 
-  go test "${go_test_args[@]}" 2>&1 | tee "${tmp_json}"
-  status=${PIPESTATUS[0]}
+  go test "${go_test_args[@]}" 2>&1 \
+    | tee "${tmp_json}" \
+    | go run ./internal/go-test-breadcrumbs --timeout "${go_test_timeout}"
+  pipeline_status=("${PIPESTATUS[@]}")
+  status=${pipeline_status[0]}
+  if [ "$status" -eq 0 ] && [ "${pipeline_status[2]}" -ne 0 ]; then
+    status=${pipeline_status[2]}
+  fi
   set -e
 
   go run github.com/jstemmer/go-junit-report/v2@v2.1.0 -parser gojson < "${tmp_json}" > junit.xml

--- a/suites/go-core/tests/timing_helpers_test.go
+++ b/suites/go-core/tests/timing_helpers_test.go
@@ -1,0 +1,30 @@
+//go:build e2e
+
+package tests
+
+import (
+	"testing"
+	"time"
+)
+
+func startTimingBreadcrumbs(t *testing.T) func(string) {
+	t.Helper()
+	started := time.Now()
+	last := started
+	t.Logf("timing: test=%s step=start total=0s", t.Name())
+	t.Cleanup(func() {
+		t.Logf("timing: test=%s step=finish total=%s", t.Name(), time.Since(started).Round(time.Millisecond))
+	})
+	return func(step string) {
+		t.Helper()
+		now := time.Now()
+		t.Logf(
+			"timing: test=%s step=%s step_elapsed=%s total=%s",
+			t.Name(),
+			step,
+			now.Sub(last).Round(time.Millisecond),
+			now.Sub(started).Round(time.Millisecond),
+		)
+		last = now
+	}
+}

--- a/suites/go-core/tests/workload_start_retry_policy_test.go
+++ b/suites/go-core/tests/workload_start_retry_policy_test.go
@@ -20,14 +20,15 @@ import (
 )
 
 const (
-	startRetryTestTimeout = 8 * time.Minute
-	failedWorkloadTimeout = 3 * time.Minute
-	fastRetryTimeout      = 40 * time.Second
-	fastRetryWindow       = 30 * time.Second
-	responseWaitTimeout   = 3 * time.Minute
-	runnerCleanupTimeout  = 90 * time.Second
-	invalidInitImage      = "INVALID_IMAGE_NAME:latest"
-	expectedAgentResponse = "Hi! How are you?"
+	startRetryTestTimeout  = 8 * time.Minute
+	failedWorkloadTimeout  = 3 * time.Minute
+	fastRetryTimeout       = 40 * time.Second
+	fastRetryWindow        = 30 * time.Second
+	startRetryPollInterval = time.Second
+	responseWaitTimeout    = 3 * time.Minute
+	runnerCleanupTimeout   = 90 * time.Second
+	invalidInitImage       = "INVALID_IMAGE_NAME:latest"
+	expectedAgentResponse  = "Hi! How are you?"
 )
 
 var configInvalidContainerReasons = map[string]struct{}{
@@ -37,6 +38,7 @@ var configInvalidContainerReasons = map[string]struct{}{
 }
 
 func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
+	logStep := startTimingBreadcrumbs(t)
 	ctx, cancel := context.WithTimeout(context.Background(), startRetryTestTimeout)
 	t.Cleanup(cancel)
 
@@ -56,6 +58,7 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 	orgID := setup.OrganizationID
 	token := setup.Token
 	modelID := createWorkflowGatewayModel(t, setup, testLLMEndpointCodex, llmv1.Protocol_PROTOCOL_RESPONSES, "simple-hello")
+	logStep("workflow_setup")
 
 	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-start-retry-%s", uuid.NewString()), modelID, orgID, invalidInitImage)
 	agentID := agent.GetMeta().GetId()
@@ -77,6 +80,7 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 
 	sentMessage := sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "hello")
 	sentMessageTime := messageCreatedAt(t, sentMessage)
+	logStep("invalid_image_message_sent")
 
 	labels := map[string]string{
 		labelManagedBy: managedByValue,
@@ -103,6 +107,7 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 	if len(failedWorkloads) < 2 {
 		t.Fatalf("expected at least 2 failed workloads, got %d", len(failedWorkloads))
 	}
+	logStep("failed_workloads_observed")
 	failedLatest := failedWorkloads[0]
 	failedPrevious := failedWorkloads[1]
 	assertFailedWorkload(t, failedLatest, threadID, agentID)
@@ -144,6 +149,7 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 	if _, err := agentsClient.UpdateAgent(updateCtx, &agentsv1.UpdateAgentRequest{Id: agentID, InitImage: &validInitImage}); err != nil {
 		t.Fatalf("update agent init image: %v", err)
 	}
+	logStep("valid_image_updated")
 
 	fastRetryCtx, fastRetryCancel := context.WithTimeout(ctx, fastRetryTimeout)
 	defer fastRetryCancel()
@@ -155,6 +161,7 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 	if retryCreatedAt.Sub(removedAt) >= fastRetryWindow {
 		t.Fatalf("expected retry within %s, got %s", fastRetryWindow, retryCreatedAt.Sub(removedAt))
 	}
+	logStep("retry_workload_observed")
 
 	responseCtx, responseCancel := context.WithTimeout(threadsCtx, responseWaitTimeout)
 	defer responseCancel()
@@ -165,19 +172,23 @@ func TestWorkloadStartRetryPolicyFastRetry(t *testing.T) {
 	if agentBody != expectedAgentResponse {
 		t.Fatalf("expected agent response %q, got %q", expectedAgentResponse, agentBody)
 	}
+	logStep("agent_response_observed")
 
+	failedInstanceIDs := make([]string, 0, 2)
 	for _, failed := range []*runnersv1.Workload{failedLatest, failedPrevious} {
 		instanceID := failed.GetInstanceId()
 		if instanceID == "" {
 			t.Fatalf("failed workload %s missing instance id", workloadID(t, failed))
 		}
-		cleanupCtx, cleanupCancel := context.WithTimeout(ctx, runnerCleanupTimeout)
-		if err := waitForRunnerWorkloadGone(cleanupCtx, runnerClient, instanceID); err != nil {
-			cleanupCancel()
-			t.Fatalf("wait for runner workload %s cleanup: %v", instanceID, err)
-		}
-		cleanupCancel()
+		failedInstanceIDs = append(failedInstanceIDs, instanceID)
 	}
+	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, runnerCleanupTimeout)
+	if err := waitForRunnerWorkloadsGone(cleanupCtx, runnerClient, failedInstanceIDs); err != nil {
+		cleanupCancel()
+		t.Fatalf("wait for runner workload cleanup: %v", err)
+	}
+	cleanupCancel()
+	logStep("failed_runner_workloads_cleaned")
 }
 
 func waitForFailedWorkloads(
@@ -191,7 +202,7 @@ func waitForFailedWorkloads(
 		return nil, fmt.Errorf("expected positive count, got %d", count)
 	}
 	var failed []*runnersv1.Workload
-	err := pollUntil(ctx, pollInterval, func(ctx context.Context) error {
+	err := pollUntil(ctx, startRetryPollInterval, func(ctx context.Context) error {
 		workloads, err := listWorkloadsByThread(ctx, client, threadID, agentID, []runnersv1.WorkloadStatus{runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED})
 		if err != nil {
 			return err
@@ -263,7 +274,7 @@ func waitForRetryWorkload(
 		return nil, fmt.Errorf("removed_at is zero")
 	}
 	var retry *runnersv1.Workload
-	err := pollUntil(ctx, pollInterval, func(ctx context.Context) error {
+	err := pollUntil(ctx, startRetryPollInterval, func(ctx context.Context) error {
 		workloads, err := listWorkloadsByThread(ctx, client, threadID, agentID, nil)
 		if err != nil {
 			return err
@@ -364,16 +375,55 @@ func waitForRunnerWorkloadGone(ctx context.Context, client runnerv1.RunnerServic
 	if workloadID == "" {
 		return fmt.Errorf("workload id is empty")
 	}
-	return pollUntil(ctx, pollInterval, func(ctx context.Context) error {
-		_, err := client.InspectWorkload(ctx, &runnerv1.InspectWorkloadRequest{WorkloadId: workloadID})
-		if err != nil {
-			if status.Code(err) == codes.NotFound {
-				return nil
-			}
-			return err
+	return waitForRunnerWorkloadsGone(ctx, client, []string{workloadID})
+}
+
+func waitForRunnerWorkloadsGone(ctx context.Context, client runnerv1.RunnerServiceClient, workloadIDs []string) error {
+	if len(workloadIDs) == 0 {
+		return fmt.Errorf("workload ids are empty")
+	}
+	remaining := make(map[string]struct{}, len(workloadIDs))
+	for _, workloadID := range workloadIDs {
+		if workloadID == "" {
+			return fmt.Errorf("workload id is empty")
 		}
-		return fmt.Errorf("workload %s still present", workloadID)
+		remaining[workloadID] = struct{}{}
+	}
+	return pollUntil(ctx, startRetryPollInterval, func(ctx context.Context) error {
+		for workloadID := range remaining {
+			gone, err := runnerWorkloadGone(ctx, client, workloadID)
+			if err != nil {
+				return err
+			}
+			if gone {
+				delete(remaining, workloadID)
+			}
+		}
+		if len(remaining) == 0 {
+			return nil
+		}
+		return fmt.Errorf("workloads still present: %s", sortedMapKeys(remaining))
 	})
+}
+
+func runnerWorkloadGone(ctx context.Context, client runnerv1.RunnerServiceClient, workloadID string) (bool, error) {
+	_, err := client.InspectWorkload(ctx, &runnerv1.InspectWorkloadRequest{WorkloadId: workloadID})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
+func sortedMapKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func assertFailedWorkload(t *testing.T, workload *runnersv1.Workload, threadID, agentID string) {


### PR DESCRIPTION
## Summary
- Set go-core E2E `go test` to an explicit `25m` package watchdog by default (`E2E_GO_TEST_TIMEOUT` can override it), so the 8m per-test contexts are not killed by Go's implicit 10m package timeout.
- Pipe go test JSON through a timing breadcrumb helper that preserves normal test output and emits package/test start, finish, elapsed, and periodic active-test breadcrumbs.
- Add per-step timing breadcrumbs to `TestWorkloadStartRetryPolicyFastRetry` and reduce its retry-policy polling interval to 1s for faster invalid-image/retry detection.
- Check both failed workload cleanups in a shared polling loop instead of spending up to one cleanup timeout per workload.

Fixes #166

## Test & Lint Summary
- `go test ./internal/go-test-breadcrumbs ./tests/...`: 2 passed, 0 failed, 0 skipped.
- `go test -tags 'e2e svc_agents_orchestrator' -run '^$' ./tests/...`: 0 passed, 0 failed, 0 skipped (compile-only for E2E-tagged tests).
- `shellcheck scripts/run-pipeline.sh`: passed with no errors.
- `python3 scripts/parse_suite.py suites/go-core/suite.yaml /tmp/go-core-suite-parse4 && shellcheck /tmp/go-core-run4.sh`: passed with no errors.