### PR TITLE
fix: svc_files E2E agent setup

### DIFF
--- a/suites/go-core/tests/start_test.go
+++ b/suites/go-core/tests/start_test.go
@@ -28,30 +28,30 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 
 	setup := newWorkflowGatewaySetup(t, ctx)
 	identityID := setup.IdentityID
-	threadsCtx := setup.Context
+	identityCtx := setup.Context
 	orgID := setup.OrganizationID
 	token := setup.Token
 	modelID := setup.ModelID
 
-	agent := createAgent(t, threadsCtx, agentsClient, fmt.Sprintf("e2e-test-agent-start-%s", uuid.NewString()), modelID, orgID, codexInitImage)
+	agent := createAgent(t, identityCtx, agentsClient, fmt.Sprintf("e2e-test-agent-start-%s", uuid.NewString()), modelID, orgID, codexInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
 	t.Cleanup(func() {
-		cleanupAgentEnvs(t, threadsCtx, agentsClient, agentID)
-		deleteAgent(t, threadsCtx, agentsClient, agentID)
+		cleanupAgentEnvs(t, identityCtx, agentsClient, agentID)
+		deleteAgent(t, identityCtx, agentsClient, agentID)
 	})
-	createAgentEnv(t, threadsCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
+	createAgentEnv(t, identityCtx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, identityCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, identityCtx, threadsClient, threadID) })
 
-	_ = sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "e2e test message")
+	_ = sendMessage(t, identityCtx, threadsClient, threadID, identityID, "e2e test message")
 
 	labels := map[string]string{
 		labelManagedBy: managedByValue,

--- a/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
@@ -54,4 +54,24 @@ test.describe('chat api helpers', () => {
       availability: AgentAvailability.PRIVATE,
     });
   });
+
+  test('CreateAgent ConnectRPC JSON uses private protobuf enum name', () => {
+    const payload = buildCreateAgentRequestJson({
+      ...createAgentOptions,
+      availability: AgentAvailability.PRIVATE,
+    });
+
+    expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
+      availability: 'AGENT_AVAILABILITY_PRIVATE',
+    });
+  });
+
+  test('CreateAgent rejects unsupported availability enum', () => {
+    expect(() =>
+      buildCreateAgentPayload({
+        ...createAgentOptions,
+        availability: AgentAvailability.UNSPECIFIED,
+      }),
+    ).toThrow('Unsupported agent availability: 0');
+  });
 });


### PR DESCRIPTION
## Summary
- use the workflow identity metadata context explicitly for `TestWorkloadStartsOnUnackedMessage` agent/thread setup and cleanup calls
- extend chat-app CreateAgent helper regression coverage for private availability JSON serialization and unsupported enum rejection
- verified existing CreateAgent helper still defaults availability to `AgentAvailability.INTERNAL` and sends generated protobuf bytes with `encoding: 'proto'`

Fixes #168

## Test & lint summary
- `CGO_ENABLED=0 go test -run TestDoesNotExist -tags "e2e svc_agents_orchestrator" ./tests/...` — passed: 0, failed: 0, skipped: 0 (`[no tests to run]` build/tag check passed)
- `CGO_ENABLED=0 go test -run TestDoesNotExist -tags "e2e svc_files" ./tests/...` — passed: 0, failed: 0, skipped: 0 (`[no tests to run]` build/tag check passed)
- `E2E_BASE_URL=http://localhost npx playwright test test/e2e/chat-api.spec.ts --reporter=list` — passed: 6, failed: 0, skipped: 0
- `E2E_BASE_URL=http://localhost npx tsc --noEmit` — lint/typecheck passed with no errors

Note: targeted live `TestWorkloadStartsOnUnackedMessage` was attempted locally, but this workspace has no reachable in-cluster `agents:50051` service, so it fails at service dial before exercising test logic.