### PR TITLE
docs: improve README E2E sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ suite in a Kubernetes pod.
 For BDD coverage, tag conventions, and traceability references, see the
 [E2E BDD documentation](docs/e2e/README.md).
 
+## Microservice E2E status
+
+<!-- markdownlint-disable MD013 -->
+
+| Service | E2E | Service | E2E | Service | E2E |
+| --- | --- | --- | --- | --- | --- |
+| [agent-state](https://github.com/agynio/agent-state) | [![E2E](https://github.com/agynio/agent-state/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agent-state/actions/workflows/e2e.yml?query=branch:main) | [agents](https://github.com/agynio/agents) | [![E2E](https://github.com/agynio/agents/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agents/actions/workflows/e2e.yml?query=branch:main) | [agents-orchestrator](https://github.com/agynio/agents-orchestrator) | [![E2E](https://github.com/agynio/agents-orchestrator/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agents-orchestrator/actions/workflows/e2e.yml?query=branch:main) |
+| [agn-cli](https://github.com/agynio/agn-cli) | [![E2E](https://github.com/agynio/agn-cli/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agn-cli/actions/workflows/e2e.yml?query=branch:main) | [agynd-cli](https://github.com/agynio/agynd-cli) | [![E2E](https://github.com/agynio/agynd-cli/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agynd-cli/actions/workflows/e2e.yml?query=branch:main) | [apps](https://github.com/agynio/apps) | [![E2E](https://github.com/agynio/apps/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/apps/actions/workflows/e2e.yml?query=branch:main) |
+| [authorization](https://github.com/agynio/authorization) | [![E2E](https://github.com/agynio/authorization/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/authorization/actions/workflows/e2e.yml?query=branch:main) | [chat-app](https://github.com/agynio/chat-app) | [![E2E](https://github.com/agynio/chat-app/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/chat-app/actions/workflows/e2e.yml?query=branch:main) | [console-app](https://github.com/agynio/console-app) | [![E2E](https://github.com/agynio/console-app/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/console-app/actions/workflows/e2e.yml?query=branch:main) |
+| [files](https://github.com/agynio/files) | [![E2E](https://github.com/agynio/files/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/files/actions/workflows/e2e.yml?query=branch:main) | [files-mcp](https://github.com/agynio/files-mcp) | [![E2E](https://github.com/agynio/files-mcp/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/files-mcp/actions/workflows/e2e.yml?query=branch:main) | [gateway](https://github.com/agynio/gateway) | [![E2E](https://github.com/agynio/gateway/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/gateway/actions/workflows/e2e.yml?query=branch:main) |
+| [identity](https://github.com/agynio/identity) | [![E2E](https://github.com/agynio/identity/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/identity/actions/workflows/e2e.yml?query=branch:main) | [k8s-runner](https://github.com/agynio/k8s-runner) | [![E2E](https://github.com/agynio/k8s-runner/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/k8s-runner/actions/workflows/e2e.yml?query=branch:main) | [llm](https://github.com/agynio/llm) | [![E2E](https://github.com/agynio/llm/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/llm/actions/workflows/e2e.yml?query=branch:main) |
+| [llm-proxy](https://github.com/agynio/llm-proxy) | [![E2E](https://github.com/agynio/llm-proxy/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/llm-proxy/actions/workflows/e2e.yml?query=branch:main) | [media-proxy](https://github.com/agynio/media-proxy) | [![E2E](https://github.com/agynio/media-proxy/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/media-proxy/actions/workflows/e2e.yml?query=branch:main) | [metering](https://github.com/agynio/metering) | [![E2E](https://github.com/agynio/metering/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/metering/actions/workflows/e2e.yml?query=branch:main) |
+| [organizations](https://github.com/agynio/organizations) | [![E2E](https://github.com/agynio/organizations/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/organizations/actions/workflows/e2e.yml?query=branch:main) | [runners](https://github.com/agynio/runners) | [![E2E](https://github.com/agynio/runners/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/runners/actions/workflows/e2e.yml?query=branch:main) | [tracing-app](https://github.com/agynio/tracing-app) | [![E2E](https://github.com/agynio/tracing-app/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/tracing-app/actions/workflows/e2e.yml?query=branch:main) |
+
+<!-- markdownlint-enable MD013 -->
+
 ## Run
 
 Run the selected suites through DevSpace:
@@ -54,27 +70,57 @@ Each suite declares a `select` script in `suite.yaml`.
 
 ## Suites
 
-<!-- markdownlint-disable MD013 -->
+### `go-agn-cli`
 
-| Suite | Default `TAGS` behavior | Suite tags | Required env vars | Playwright base URL default |
-| --- | --- | --- | --- | --- |
-| `go-agn-cli` | Not selected by default. Runs when `TAGS` includes `svc_agn_cli`. | `svc_agn_cli` | None in `suite.yaml`. Runtime expects `AGN_BINARY`, or `./bin/agn` by default. | N/A |
-| `go-core` | Selected as `smoke`; runs Go tests with `e2e smoke`. | `svc_agents_orchestrator`, `svc_runners`, `svc_metering`, `svc_k8s_runner`, `svc_organizations`, `svc_files`, `svc_gateway`, `svc_media_proxy`, `svc_llm`, `svc_llm_proxy`, `smoke` | `AGN_INIT_IMAGE`, `CODEX_INIT_IMAGE`, `CLAUDE_INIT_IMAGE`, `AGN_EXPOSE_INIT_IMAGE` | N/A |
-| `go-terraform` | Selected as `svc_gateway`; runs Go tests with `e2e svc_gateway tf_provider_agyn` when `TAGS` is empty. | `svc_gateway`, `tf_provider_agyn` | None in `suite.yaml`. | N/A |
-| `playwright` | Selected by default and runs the full Playwright suite with no grep. | `svc_console`, `svc_gateway`, `svc_threads`, `svc_metering`, `svc_identity`, `smoke` | None in `suite.yaml`. | `https://console.${E2E_DOMAIN:-agyn.dev}` |
-| `playwright-chat-app` | Not selected by default. Runs when `TAGS` matches one of its suite tags. | `svc_chat_app`, `svc_gateway`, `svc_agents_orchestrator`, `svc_organizations`, `svc_files`, `svc_media_proxy`, `svc_tracing_app` | `CODEX_INIT_IMAGE` | `https://chat.${E2E_DOMAIN:-agyn.dev}` |
-| `playwright-tracing-app` | Selected as `smoke`; runs Playwright with `--grep @smoke`. | `svc_tracing_app`, `svc_agents_orchestrator`, `smoke` | `AGN_INIT_IMAGE`, `CODEX_INIT_IMAGE`, `CLAUDE_INIT_IMAGE` | `https://tracing.${E2E_DOMAIN:-agyn.dev}` |
+- **Default `TAGS` behavior:** Not selected by default. Runs when `TAGS`
+  includes `svc_agn_cli`.
+- **Suite tags:** `svc_agn_cli`
+- **Required env vars:** None in `suite.yaml`. Runtime expects `AGN_BINARY`, or
+  `./bin/agn` by default.
+- **Playwright base URL default:** N/A
 
-<!-- markdownlint-enable MD013 -->
+### `go-core`
 
-## Microservice E2E status
+- **Default `TAGS` behavior:** Selected as `smoke`; runs Go tests with
+  `e2e smoke`.
+- **Suite tags:** `svc_agents_orchestrator`, `svc_runners`, `svc_metering`,
+  `svc_k8s_runner`, `svc_organizations`, `svc_files`, `svc_gateway`,
+  `svc_media_proxy`, `svc_llm`, `svc_llm_proxy`, `smoke`
+- **Required env vars:** `AGN_INIT_IMAGE`, `CODEX_INIT_IMAGE`,
+  `CLAUDE_INIT_IMAGE`, `AGN_EXPOSE_INIT_IMAGE`
+- **Playwright base URL default:** N/A
 
-| Service | E2E | Service | E2E | Service | E2E |
-| --- | --- | --- | --- | --- | --- |
-| [agent-state](https://github.com/agynio/agent-state) | [![E2E](https://github.com/agynio/agent-state/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agent-state/actions/workflows/e2e.yml?query=branch:main) | [agents](https://github.com/agynio/agents) | [![E2E](https://github.com/agynio/agents/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agents/actions/workflows/e2e.yml?query=branch:main) | [agents-orchestrator](https://github.com/agynio/agents-orchestrator) | [![E2E](https://github.com/agynio/agents-orchestrator/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agents-orchestrator/actions/workflows/e2e.yml?query=branch:main) |
-| [agn-cli](https://github.com/agynio/agn-cli) | [![E2E](https://github.com/agynio/agn-cli/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agn-cli/actions/workflows/e2e.yml?query=branch:main) | [agynd-cli](https://github.com/agynio/agynd-cli) | [![E2E](https://github.com/agynio/agynd-cli/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/agynd-cli/actions/workflows/e2e.yml?query=branch:main) | [apps](https://github.com/agynio/apps) | [![E2E](https://github.com/agynio/apps/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/apps/actions/workflows/e2e.yml?query=branch:main) |
-| [authorization](https://github.com/agynio/authorization) | [![E2E](https://github.com/agynio/authorization/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/authorization/actions/workflows/e2e.yml?query=branch:main) | [chat-app](https://github.com/agynio/chat-app) | [![E2E](https://github.com/agynio/chat-app/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/chat-app/actions/workflows/e2e.yml?query=branch:main) | [console-app](https://github.com/agynio/console-app) | [![E2E](https://github.com/agynio/console-app/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/console-app/actions/workflows/e2e.yml?query=branch:main) |
-| [files](https://github.com/agynio/files) | [![E2E](https://github.com/agynio/files/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/files/actions/workflows/e2e.yml?query=branch:main) | [files-mcp](https://github.com/agynio/files-mcp) | [![E2E](https://github.com/agynio/files-mcp/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/files-mcp/actions/workflows/e2e.yml?query=branch:main) | [gateway](https://github.com/agynio/gateway) | [![E2E](https://github.com/agynio/gateway/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/gateway/actions/workflows/e2e.yml?query=branch:main) |
-| [identity](https://github.com/agynio/identity) | [![E2E](https://github.com/agynio/identity/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/identity/actions/workflows/e2e.yml?query=branch:main) | [k8s-runner](https://github.com/agynio/k8s-runner) | [![E2E](https://github.com/agynio/k8s-runner/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/k8s-runner/actions/workflows/e2e.yml?query=branch:main) | [llm](https://github.com/agynio/llm) | [![E2E](https://github.com/agynio/llm/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/llm/actions/workflows/e2e.yml?query=branch:main) |
-| [llm-proxy](https://github.com/agynio/llm-proxy) | [![E2E](https://github.com/agynio/llm-proxy/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/llm-proxy/actions/workflows/e2e.yml?query=branch:main) | [media-proxy](https://github.com/agynio/media-proxy) | [![E2E](https://github.com/agynio/media-proxy/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/media-proxy/actions/workflows/e2e.yml?query=branch:main) | [metering](https://github.com/agynio/metering) | [![E2E](https://github.com/agynio/metering/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/metering/actions/workflows/e2e.yml?query=branch:main) |
-| [organizations](https://github.com/agynio/organizations) | [![E2E](https://github.com/agynio/organizations/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/organizations/actions/workflows/e2e.yml?query=branch:main) | [runners](https://github.com/agynio/runners) | [![E2E](https://github.com/agynio/runners/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/runners/actions/workflows/e2e.yml?query=branch:main) | [tracing-app](https://github.com/agynio/tracing-app) | [![E2E](https://github.com/agynio/tracing-app/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/agynio/tracing-app/actions/workflows/e2e.yml?query=branch:main) |
+### `go-terraform`
+
+- **Default `TAGS` behavior:** Selected as `svc_gateway`; runs Go tests with
+  `e2e svc_gateway tf_provider_agyn` when `TAGS` is empty.
+- **Suite tags:** `svc_gateway`, `tf_provider_agyn`
+- **Required env vars:** None in `suite.yaml`.
+- **Playwright base URL default:** N/A
+
+### `playwright`
+
+- **Default `TAGS` behavior:** Selected by default and runs the full Playwright
+  suite with no grep.
+- **Suite tags:** `svc_console`, `svc_gateway`, `svc_threads`, `svc_metering`,
+  `svc_identity`, `smoke`
+- **Required env vars:** None in `suite.yaml`.
+- **Playwright base URL default:** `https://console.${E2E_DOMAIN:-agyn.dev}`
+
+### `playwright-chat-app`
+
+- **Default `TAGS` behavior:** Not selected by default. Runs when `TAGS`
+  matches one of its suite tags.
+- **Suite tags:** `svc_chat_app`, `svc_gateway`, `svc_agents_orchestrator`,
+  `svc_organizations`, `svc_files`, `svc_media_proxy`, `svc_tracing_app`
+- **Required env vars:** `CODEX_INIT_IMAGE`
+- **Playwright base URL default:** `https://chat.${E2E_DOMAIN:-agyn.dev}`
+
+### `playwright-tracing-app`
+
+- **Default `TAGS` behavior:** Selected as `smoke`; runs Playwright with
+  `--grep @smoke`.
+- **Suite tags:** `svc_tracing_app`, `svc_agents_orchestrator`, `smoke`
+- **Required env vars:** `AGN_INIT_IMAGE`, `CODEX_INIT_IMAGE`,
+  `CLAUDE_INIT_IMAGE`
+- **Playwright base URL default:** `https://tracing.${E2E_DOMAIN:-agyn.dev}`


### PR DESCRIPTION
## Summary
- Moves the Microservice E2E status section directly after the intro and BDD docs link.
- Replaces the wide Suites table with per-suite headings and wrapped bullet lists.
- Keeps suite tags, default selection behavior, required env vars, and base URL defaults aligned with `suites/*/suite.yaml`.

Closes #178

## Test & Lint Summary
- `npx --yes markdownlint-cli README.md`: 1 file passed, 0 failed, 0 skipped.
- `git diff --check`: 1 diff passed, 0 failed, 0 skipped.
- README suite data verification script: 1 check passed, 0 failed, 0 skipped.
- Linting passed with no errors.