### PR TITLE
docs(e2e): warn on ziti diagnostics secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ suite in a Kubernetes pod.
 For BDD coverage, tag conventions, and traceability references, see the
 [E2E BDD documentation](docs/e2e/README.md).
 
+## DEV/E2E-only Ziti diagnostics credentials
+
+Some expose diagnostics tests read a Kubernetes secret named
+`ziti-management-diagnostics`. That secret and its matching OpenZiti identity
+are for development and E2E diagnostics only, and must not exist in production
+deployments.
+
+The bootstrap Terraform stack must guard the resources with
+`enable_ziti_management_diagnostics`, which defaults to `false`. Only E2E/dev
+bootstrap runs should enable the flag; production deployments must keep it
+disabled.
+
 ## Microservice E2E status
 
 <!-- markdownlint-disable MD013 -->

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -20,6 +20,14 @@ Additional references:
 - [Service coverage](traceability/service-coverage.md)
 - [Architecture and product anchors](traceability/architecture-product-anchors.md)
 
+## DEV/E2E-only diagnostics resources
+
+The `ziti-management-diagnostics` identity and Kubernetes secret are test-only
+diagnostics resources. They are allowed only in development and E2E bootstrap
+deployments, must be guarded by the bootstrap Terraform variable
+`enable_ziti_management_diagnostics` defaulting to `false`, and must not exist
+in production deployments.
+
 ## Tag glossary
 
 Tags are selected through suite-level `TAGS` filtering. Suite docs list suite tags from `suites/*/suite.yaml`; individual case tags mirror the nearest Playwright `test.describe` tag or the service area implied by the Go test file.

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -27,21 +27,23 @@ import (
 )
 
 const (
-	exposeTestTimeout          = 8 * time.Minute
-	exposeCommandTimeout       = 2 * time.Minute
-	exposeListTimeout          = 30 * time.Second
-	exposeListEmptyTimeout     = 60 * time.Second
-	exposeReachabilityTimeout  = 90 * time.Second
-	exposeUnreachableTimeout   = 90 * time.Second
-	exposeRequestTimeout       = 15 * time.Second
-	exposeZitiRequestTimeout   = 30 * time.Second
-	exposeDiagnosticsTimeout   = 20 * time.Second
-	exposePort                 = 3000
-	exposeExpectedResponse     = "Hi! How are you?"
-	exposeStatusActive         = "active"
-	zitiMgmtEndpointEnvKey     = "ZITI_MGMT_ENDPOINT"
-	zitiMgmtServiceName        = "ziti-mgmt"
-	zitiMgmtPath               = "/edge/management/v1"
+	exposeTestTimeout         = 8 * time.Minute
+	exposeCommandTimeout      = 2 * time.Minute
+	exposeListTimeout         = 30 * time.Second
+	exposeListEmptyTimeout    = 60 * time.Second
+	exposeReachabilityTimeout = 90 * time.Second
+	exposeUnreachableTimeout  = 90 * time.Second
+	exposeRequestTimeout      = 15 * time.Second
+	exposeZitiRequestTimeout  = 30 * time.Second
+	exposeDiagnosticsTimeout  = 20 * time.Second
+	exposePort                = 3000
+	exposeExpectedResponse    = "Hi! How are you?"
+	exposeStatusActive        = "active"
+	zitiMgmtEndpointEnvKey    = "ZITI_MGMT_ENDPOINT"
+	zitiMgmtServiceName       = "ziti-mgmt"
+	zitiMgmtPath              = "/edge/management/v1"
+	// DEV/E2E ONLY: ziti-management-diagnostics must only exist in dev/E2E
+	// bootstrap deployments and must never be enabled in production.
 	zitiDiagnosticsSecretName  = "ziti-management-diagnostics"
 	zitiDiagnosticsUserKey     = "username"
 	zitiDiagnosticsPasswordKey = "password"


### PR DESCRIPTION
## Summary

- Adds explicit DEV/E2E-only warnings around the `ziti-management-diagnostics` secret used by expose diagnostics tests.
- Documents that the matching OpenZiti identity and Kubernetes secret must not exist in production.
- Notes that bootstrap must keep `enable_ziti_management_diagnostics` defaulted to `false` and only enable it for E2E/dev runs.

## Related

Follow-up to merged PR #172. Complements agynio/bootstrap#544.

Fixes #170

## Test & Lint Summary

- `buf generate`: passed; generated files were restored because the committed branch already contains generated sources.
- `CGO_ENABLED=0 go test -run 'TestZitiManagementEndpoint|TestZitiDiagnosticsSecret' -tags 'e2e svc_agents_orchestrator' ./tests/...`: 3 passed / 0 failed / 0 skipped; tracecanary had no test files.
- `gofmt -w tests/expose_test.go`: passed with no formatting errors.
- `test -z "$(gofmt -l tests/expose_test.go)"`: passed; lint/format check reported no errors.
