### PR TITLE
refactor(e2e): share ziti diagnostics helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,14 @@ For BDD coverage, tag conventions, and traceability references, see the
 
 ## DEV/E2E-only Ziti diagnostics credentials
 
-Some expose diagnostics tests read a Kubernetes secret named
-`ziti-management-diagnostics`. That secret and its matching OpenZiti identity
-are for development and E2E diagnostics only, and must not exist in production
-deployments.
+The shared Go E2E diagnostics helpers can optionally read a Kubernetes secret
+named `ziti-diagnostics` to query OpenZiti management state after failures.
+That secret and its matching OpenZiti identity are for development and E2E
+diagnostics only, and must not exist in production deployments.
 
 The bootstrap Terraform stack must guard the resources with
-`enable_ziti_management_diagnostics`, which defaults to `false`. Only E2E/dev
-bootstrap runs should enable the flag; production deployments must keep it
-disabled.
+`enable_ziti_diagnostics`, which defaults to `false`. Only E2E/dev bootstrap
+runs should enable the flag; production deployments must keep it disabled.
 
 ## Microservice E2E status
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ named `ziti-diagnostics` to query OpenZiti management state after failures.
 That secret and its matching OpenZiti identity are for development and E2E
 diagnostics only, and must not exist in production deployments.
 
+By default, helpers read `platform/ziti-diagnostics`, matching bootstrap.
+Override with `ZITI_DIAGNOSTICS_SECRET_NAMESPACE` and
+`ZITI_DIAGNOSTICS_SECRET_NAME` when a non-default namespace or secret name is
+required.
+
 The bootstrap Terraform stack must guard the resources with
 `enable_ziti_diagnostics`, which defaults to `false`. Only E2E/dev bootstrap
 runs should enable the flag; production deployments must keep it disabled.

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -28,6 +28,10 @@ They are allowed only in development and E2E bootstrap deployments, must be
 guarded by the bootstrap Terraform variable `enable_ziti_diagnostics`
 defaulting to `false`, and must not exist in production deployments.
 
+The helper defaults to the bootstrap-managed `platform/ziti-diagnostics` secret.
+Use `ZITI_DIAGNOSTICS_SECRET_NAMESPACE` and `ZITI_DIAGNOSTICS_SECRET_NAME` for
+non-default development or E2E deployments.
+
 ## Tag glossary
 
 Tags are selected through suite-level `TAGS` filtering. Suite docs list suite tags from `suites/*/suite.yaml`; individual case tags mirror the nearest Playwright `test.describe` tag or the service area implied by the Go test file.

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -22,11 +22,11 @@ Additional references:
 
 ## DEV/E2E-only diagnostics resources
 
-The `ziti-management-diagnostics` identity and Kubernetes secret are test-only
-diagnostics resources. They are allowed only in development and E2E bootstrap
-deployments, must be guarded by the bootstrap Terraform variable
-`enable_ziti_management_diagnostics` defaulting to `false`, and must not exist
-in production deployments.
+The `ziti-diagnostics` identity and Kubernetes secret are shared diagnostics
+resources used by E2E helpers to query OpenZiti management state after failures.
+They are allowed only in development and E2E bootstrap deployments, must be
+guarded by the bootstrap Terraform variable `enable_ziti_diagnostics`
+defaulting to `false`, and must not exist in production deployments.
 
 ## Tag glossary
 

--- a/suites/go-core/suite.yaml
+++ b/suites/go-core/suite.yaml
@@ -66,6 +66,11 @@ run: |
   fi
   set -e
 
+  if [ "$status" -ne 0 ]; then
+    E2E_ZITI_DIAGNOSTICS_DUMP=1 \
+      go test -count=1 -timeout 1m -tags "${tag_args}" -run '^TestZitiDiagnosticsDump$' -v ./tests/... || true
+  fi
+
   go run github.com/jstemmer/go-junit-report/v2@v2.1.0 -parser gojson < "${tmp_json}" > junit.xml
   rm -f "${tmp_json}"
 

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -4,7 +4,6 @@ package tests
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,58 +38,7 @@ const (
 	exposePort                = 3000
 	exposeExpectedResponse    = "Hi! How are you?"
 	exposeStatusActive        = "active"
-	zitiMgmtEndpointEnvKey    = "ZITI_MGMT_ENDPOINT"
-	zitiMgmtServiceName       = "ziti-mgmt"
-	zitiMgmtPath              = "/edge/management/v1"
-	// DEV/E2E ONLY: ziti-management-diagnostics must only exist in dev/E2E
-	// bootstrap deployments and must never be enabled in production.
-	zitiDiagnosticsSecretName  = "ziti-management-diagnostics"
-	zitiDiagnosticsUserKey     = "username"
-	zitiDiagnosticsPasswordKey = "password"
 )
-
-func TestZitiManagementEndpointDefaultUsesIngress(t *testing.T) {
-	t.Setenv(zitiMgmtEndpointEnvKey, "")
-	t.Setenv("E2E_DOMAIN", "e2e.agyn.dev")
-	t.Setenv("E2E_INGRESS_PORT", "30443")
-
-	got := zitiManagementEndpoint()
-	want := "https://ziti-mgmt.e2e.agyn.dev:30443/edge/management/v1"
-	if got != want {
-		t.Fatalf("ziti management endpoint mismatch: got %q want %q", got, want)
-	}
-}
-
-func TestZitiManagementEndpointExplicitOverride(t *testing.T) {
-	t.Setenv(zitiMgmtEndpointEnvKey, "https://custom.example.test:9443/edge/management/v1/")
-
-	got := zitiManagementEndpoint()
-	want := "https://custom.example.test:9443/edge/management/v1"
-	if got != want {
-		t.Fatalf("ziti management endpoint mismatch: got %q want %q", got, want)
-	}
-}
-
-func TestZitiDiagnosticsSecretUsesPlatformNamespace(t *testing.T) {
-	secretNamespace, secretName := zitiDiagnosticsSecretRef()
-	if secretNamespace != "platform" {
-		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "platform")
-	}
-	if secretName != zitiDiagnosticsSecretName {
-		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsSecretName)
-	}
-}
-
-func TestZitiDiagnosticsSecretUsesDevspaceNamespace(t *testing.T) {
-	t.Setenv("DEVSPACE_NAMESPACE", "custom-platform")
-	secretNamespace, secretName := zitiDiagnosticsSecretRef()
-	if secretNamespace != "custom-platform" {
-		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "custom-platform")
-	}
-	if secretName != zitiDiagnosticsSecretName {
-		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsSecretName)
-	}
-}
 
 type exposeWorkloadFixture struct {
 	ctx           context.Context
@@ -116,6 +64,7 @@ type exposeEntry struct {
 }
 
 func TestAgentExposeListExec(t *testing.T) {
+	registerZitiFailureDiagnostics(t)
 	fixture := setupExposeTestWorkload(t)
 
 	execCtx, execCancel := context.WithTimeout(fixture.ctx, exposeCommandTimeout)
@@ -127,6 +76,7 @@ func TestAgentExposeListExec(t *testing.T) {
 }
 
 func TestAgentExposeLifecycle_ListAddRemove(t *testing.T) {
+	registerZitiFailureDiagnostics(t)
 	fixture := setupExposeTestWorkload(t)
 
 	listCtx, listCancel := context.WithTimeout(fixture.ctx, exposeCommandTimeout)
@@ -654,18 +604,6 @@ func createZitiHTTPClient(t *testing.T) *http.Client {
 	return httpClient
 }
 
-type zitiManagementSession struct {
-	endpoint string
-	token    string
-	client   *http.Client
-}
-
-type zitiAuthenticationResponse struct {
-	Data struct {
-		Token string `json:"token"`
-	} `json:"data"`
-}
-
 func logExposeTimeoutDiagnostics(t *testing.T, fixture exposeWorkloadFixture, exposure exposeEntry, exposedURL string) {
 	t.Helper()
 	t.Log("diagnostics: exposed service reachability timed out")
@@ -705,128 +643,23 @@ func logExposureDetails(t *testing.T, exposure exposeEntry, serviceName, dialURL
 
 func logZitiExposureDiagnostics(t *testing.T, ctx context.Context, serviceName string, exposure exposeEntry) {
 	t.Helper()
-	session, err := createZitiManagementSession(t, ctx)
-	if err != nil {
-		t.Logf("diagnostics: ziti management unavailable: %v", err)
-		return
+
+	queries := []zitiDiagnosticsQuery{
+		{Label: "service", Path: zitiFilterPath("/services", "name", serviceName)},
+		{Label: "terminators", Path: zitiFilterPath("/terminators", "service.name", serviceName)},
+		{Label: "bind-policy", Path: zitiFilterPath("/service-policies", "name", serviceName+"-bind")},
+		{Label: "dial-policy", Path: zitiFilterPath("/service-policies", "name", serviceName+"-dial")},
 	}
-
-	logZitiResource(t, ctx, session, "service", zitiFilterPath("/services", "name", serviceName))
-	logZitiResource(t, ctx, session, "terminators", zitiFilterPath("/terminators", "service.name", serviceName))
-	logZitiResource(t, ctx, session, "bind-policy", zitiFilterPath("/service-policies", "name", serviceName+"-bind"))
-	logZitiResource(t, ctx, session, "dial-policy", zitiFilterPath("/service-policies", "name", serviceName+"-dial"))
-
 	if exposure.OpenZitiServiceID != "" {
-		logZitiResource(t, ctx, session, "service-by-id", "/services/"+url.PathEscape(exposure.OpenZitiServiceID))
+		queries = append(queries, zitiDiagnosticsQuery{Label: "service-by-id", Path: "/services/" + url.PathEscape(exposure.OpenZitiServiceID)})
 	}
 	if exposure.OpenZitiBindPolicyID != "" {
-		logZitiResource(t, ctx, session, "bind-policy-by-id", "/service-policies/"+url.PathEscape(exposure.OpenZitiBindPolicyID))
+		queries = append(queries, zitiDiagnosticsQuery{Label: "bind-policy-by-id", Path: "/service-policies/" + url.PathEscape(exposure.OpenZitiBindPolicyID)})
 	}
 	if exposure.OpenZitiDialPolicyID != "" {
-		logZitiResource(t, ctx, session, "dial-policy-by-id", "/service-policies/"+url.PathEscape(exposure.OpenZitiDialPolicyID))
+		queries = append(queries, zitiDiagnosticsQuery{Label: "dial-policy-by-id", Path: "/service-policies/" + url.PathEscape(exposure.OpenZitiDialPolicyID)})
 	}
-}
-
-func zitiFilterPath(resourcePath, field, value string) string {
-	return fmt.Sprintf("%s?filter=%s%%3D%%22%s%%22", resourcePath, url.QueryEscape(field), url.QueryEscape(value))
-}
-
-func createZitiManagementSession(t *testing.T, ctx context.Context) (zitiManagementSession, error) {
-	t.Helper()
-	username, password, err := zitiDiagnosticsCredentials(t, ctx)
-	if err != nil {
-		return zitiManagementSession{}, err
-	}
-
-	endpoint := zitiManagementEndpoint()
-	client := &http.Client{
-		Timeout:   exposeRequestTimeout,
-		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
-	}
-	payload := fmt.Sprintf(`{"username":%q,"password":%q}`, username, password)
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/authenticate?method=password", strings.NewReader(payload))
-	if err != nil {
-		return zitiManagementSession{}, fmt.Errorf("build authenticate request: %w", err)
-	}
-	request.Header.Set("Content-Type", "application/json")
-
-	response, err := client.Do(request)
-	if err != nil {
-		return zitiManagementSession{}, fmt.Errorf("authenticate: %w", err)
-	}
-	defer response.Body.Close()
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return zitiManagementSession{}, fmt.Errorf("read authenticate response: %w", err)
-	}
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		return zitiManagementSession{}, fmt.Errorf("authenticate status %d body=%s", response.StatusCode, truncateLogLine(strings.TrimSpace(string(body))))
-	}
-
-	var auth zitiAuthenticationResponse
-	if err := json.Unmarshal(body, &auth); err != nil {
-		return zitiManagementSession{}, fmt.Errorf("parse authenticate response: %w", err)
-	}
-	token := strings.TrimSpace(auth.Data.Token)
-	if token == "" {
-		return zitiManagementSession{}, fmt.Errorf("authenticate response missing token")
-	}
-	return zitiManagementSession{endpoint: endpoint, token: token, client: client}, nil
-}
-
-func zitiDiagnosticsCredentials(t *testing.T, ctx context.Context) (string, string, error) {
-	t.Helper()
-	secretNamespace, secretName := zitiDiagnosticsSecretRef()
-	secret, err := kubeClientset(t).CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
-	if err != nil {
-		return "", "", fmt.Errorf("get %s/%s: %w", secretNamespace, secretName, err)
-	}
-	username := strings.TrimSpace(string(secret.Data[zitiDiagnosticsUserKey]))
-	password := strings.TrimSpace(string(secret.Data[zitiDiagnosticsPasswordKey]))
-	if username == "" || password == "" {
-		return "", "", fmt.Errorf("%s/%s missing diagnostics credentials", secretNamespace, secretName)
-	}
-	return username, password, nil
-}
-
-func zitiDiagnosticsSecretRef() (string, string) {
-	return envOrDefault("E2E_NAMESPACE", envOrDefault("DEVSPACE_NAMESPACE", "platform")), zitiDiagnosticsSecretName
-}
-
-func zitiManagementEndpoint() string {
-	if explicitEndpoint := strings.TrimSpace(envOrDefault(zitiMgmtEndpointEnvKey, "")); explicitEndpoint != "" {
-		return strings.TrimRight(explicitEndpoint, "/")
-	}
-	domain := envOrDefault("E2E_DOMAIN", envOrDefault("DOMAIN", "agyn.dev"))
-	port := envOrDefault("E2E_INGRESS_PORT", envOrDefault("INGRESS_PORT", envOrDefault("PORT", "2496")))
-	return strings.TrimRight(fmt.Sprintf("https://%s.%s:%s%s", zitiMgmtServiceName, domain, port, zitiMgmtPath), "/")
-}
-
-func logZitiResource(t *testing.T, ctx context.Context, session zitiManagementSession, label, path string) {
-	t.Helper()
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, session.endpoint+path, nil)
-	if err != nil {
-		t.Logf("diagnostics: ziti %s request error: %v", label, err)
-		return
-	}
-	request.Header.Set("zt-session", session.token)
-
-	response, err := session.client.Do(request)
-	if err != nil {
-		t.Logf("diagnostics: ziti %s query error: %v", label, err)
-		return
-	}
-	defer response.Body.Close()
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Logf("diagnostics: ziti %s read error: %v", label, err)
-		return
-	}
-	trimmedBody := strings.TrimSpace(string(body))
-	if trimmedBody == "" {
-		trimmedBody = "{}"
-	}
-	t.Logf("diagnostics: ziti %s status=%d body=%s", label, response.StatusCode, truncateLogLine(trimmedBody))
+	logZitiDiagnostics(t, ctx, queries)
 }
 
 func logExposeWorkloadSidecarLogs(t *testing.T, ctx context.Context, fixture exposeWorkloadFixture) {

--- a/suites/go-core/tests/ziti_diagnostics_test.go
+++ b/suites/go-core/tests/ziti_diagnostics_test.go
@@ -1,0 +1,238 @@
+//go:build e2e && (svc_agents_orchestrator || svc_runners || svc_metering || svc_k8s_runner || svc_organizations || svc_files || svc_gateway || svc_llm || svc_llm_proxy || smoke)
+
+package tests
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	zitiDiagnosticsTimeout        = 20 * time.Second
+	zitiDiagnosticsRequestTimeout = 15 * time.Second
+	zitiMgmtEndpointEnvKey        = "ZITI_MGMT_ENDPOINT"
+	zitiMgmtServiceName           = "ziti-mgmt"
+	zitiMgmtPath                  = "/edge/management/v1"
+	// DEV/E2E ONLY: ziti-diagnostics must only exist in dev/E2E bootstrap
+	// deployments and must never be enabled in production.
+	zitiDiagnosticsSecretName  = "ziti-diagnostics"
+	zitiDiagnosticsUserKey     = "username"
+	zitiDiagnosticsPasswordKey = "password"
+)
+
+type zitiDiagnosticsQuery struct {
+	Label string
+	Path  string
+}
+
+type zitiManagementSession struct {
+	endpoint string
+	token    string
+	client   *http.Client
+}
+
+type zitiAuthenticationResponse struct {
+	Data struct {
+		Token string `json:"token"`
+	} `json:"data"`
+}
+
+func TestZitiManagementEndpointDefaultUsesIngress(t *testing.T) {
+	t.Setenv(zitiMgmtEndpointEnvKey, "")
+	t.Setenv("E2E_DOMAIN", "e2e.agyn.dev")
+	t.Setenv("E2E_INGRESS_PORT", "30443")
+
+	got := zitiManagementEndpoint()
+	want := "https://ziti-mgmt.e2e.agyn.dev:30443/edge/management/v1"
+	if got != want {
+		t.Fatalf("ziti management endpoint mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestZitiManagementEndpointExplicitOverride(t *testing.T) {
+	t.Setenv(zitiMgmtEndpointEnvKey, "https://custom.example.test:9443/edge/management/v1/")
+
+	got := zitiManagementEndpoint()
+	want := "https://custom.example.test:9443/edge/management/v1"
+	if got != want {
+		t.Fatalf("ziti management endpoint mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestZitiDiagnosticsSecretUsesPlatformNamespace(t *testing.T) {
+	secretNamespace, secretName := zitiDiagnosticsSecretRef()
+	if secretNamespace != "platform" {
+		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "platform")
+	}
+	if secretName != zitiDiagnosticsSecretName {
+		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsSecretName)
+	}
+}
+
+func TestZitiDiagnosticsSecretUsesDevspaceNamespace(t *testing.T) {
+	t.Setenv("DEVSPACE_NAMESPACE", "custom-platform")
+	secretNamespace, secretName := zitiDiagnosticsSecretRef()
+	if secretNamespace != "custom-platform" {
+		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "custom-platform")
+	}
+	if secretName != zitiDiagnosticsSecretName {
+		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsSecretName)
+	}
+}
+
+func TestZitiDiagnosticsDump(t *testing.T) {
+	if strings.TrimSpace(envOrDefault("E2E_ZITI_DIAGNOSTICS_DUMP", "")) != "1" {
+		t.Skip("set E2E_ZITI_DIAGNOSTICS_DUMP=1 to dump shared Ziti diagnostics")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), zitiDiagnosticsTimeout)
+	defer cancel()
+	logZitiDiagnostics(t, ctx, nil)
+}
+
+func registerZitiFailureDiagnostics(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), zitiDiagnosticsTimeout)
+		defer cancel()
+		logZitiDiagnostics(t, ctx, nil)
+	})
+}
+
+func logZitiDiagnostics(t *testing.T, ctx context.Context, queries []zitiDiagnosticsQuery) {
+	t.Helper()
+	session, err := createZitiManagementSession(t, ctx)
+	if err != nil {
+		t.Logf("diagnostics: ziti management unavailable: %v", err)
+		return
+	}
+	if len(queries) == 0 {
+		queries = defaultZitiDiagnosticsQueries()
+	}
+	for _, query := range queries {
+		logZitiResource(t, ctx, session, query.Label, query.Path)
+	}
+}
+
+func defaultZitiDiagnosticsQueries() []zitiDiagnosticsQuery {
+	return []zitiDiagnosticsQuery{
+		{Label: "services", Path: "/services?limit=100"},
+		{Label: "terminators", Path: "/terminators?limit=100"},
+		{Label: "service-policies", Path: "/service-policies?limit=100"},
+		{Label: "identities", Path: "/identities?limit=100"},
+	}
+}
+
+func zitiFilterPath(resourcePath, field, value string) string {
+	return fmt.Sprintf("%s?filter=%s%%3D%%22%s%%22", resourcePath, url.QueryEscape(field), url.QueryEscape(value))
+}
+
+func createZitiManagementSession(t *testing.T, ctx context.Context) (zitiManagementSession, error) {
+	t.Helper()
+	username, password, err := zitiDiagnosticsCredentials(t, ctx)
+	if err != nil {
+		return zitiManagementSession{}, err
+	}
+
+	endpoint := zitiManagementEndpoint()
+	client := &http.Client{
+		Timeout:   zitiDiagnosticsRequestTimeout,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	payload := fmt.Sprintf(`{"username":%q,"password":%q}`, username, password)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/authenticate?method=password", strings.NewReader(payload))
+	if err != nil {
+		return zitiManagementSession{}, fmt.Errorf("build authenticate request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return zitiManagementSession{}, fmt.Errorf("authenticate: %w", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return zitiManagementSession{}, fmt.Errorf("read authenticate response: %w", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return zitiManagementSession{}, fmt.Errorf("authenticate status %d body=%s", response.StatusCode, truncateLogLine(strings.TrimSpace(string(body))))
+	}
+
+	var auth zitiAuthenticationResponse
+	if err := json.Unmarshal(body, &auth); err != nil {
+		return zitiManagementSession{}, fmt.Errorf("parse authenticate response: %w", err)
+	}
+	token := strings.TrimSpace(auth.Data.Token)
+	if token == "" {
+		return zitiManagementSession{}, fmt.Errorf("authenticate response missing token")
+	}
+	return zitiManagementSession{endpoint: endpoint, token: token, client: client}, nil
+}
+
+func zitiDiagnosticsCredentials(t *testing.T, ctx context.Context) (string, string, error) {
+	t.Helper()
+	secretNamespace, secretName := zitiDiagnosticsSecretRef()
+	secret, err := kubeClientset(t).CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return "", "", fmt.Errorf("get %s/%s: %w", secretNamespace, secretName, err)
+	}
+	username := strings.TrimSpace(string(secret.Data[zitiDiagnosticsUserKey]))
+	password := strings.TrimSpace(string(secret.Data[zitiDiagnosticsPasswordKey]))
+	if username == "" || password == "" {
+		return "", "", fmt.Errorf("%s/%s missing diagnostics credentials", secretNamespace, secretName)
+	}
+	return username, password, nil
+}
+
+func zitiDiagnosticsSecretRef() (string, string) {
+	return envOrDefault("E2E_NAMESPACE", envOrDefault("DEVSPACE_NAMESPACE", "platform")), zitiDiagnosticsSecretName
+}
+
+func zitiManagementEndpoint() string {
+	if explicitEndpoint := strings.TrimSpace(envOrDefault(zitiMgmtEndpointEnvKey, "")); explicitEndpoint != "" {
+		return strings.TrimRight(explicitEndpoint, "/")
+	}
+	domain := envOrDefault("E2E_DOMAIN", envOrDefault("DOMAIN", "agyn.dev"))
+	port := envOrDefault("E2E_INGRESS_PORT", envOrDefault("INGRESS_PORT", envOrDefault("PORT", "2496")))
+	return strings.TrimRight(fmt.Sprintf("https://%s.%s:%s%s", zitiMgmtServiceName, domain, port, zitiMgmtPath), "/")
+}
+
+func logZitiResource(t *testing.T, ctx context.Context, session zitiManagementSession, label, path string) {
+	t.Helper()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, session.endpoint+path, nil)
+	if err != nil {
+		t.Logf("diagnostics: ziti %s request error: %v", label, err)
+		return
+	}
+	request.Header.Set("zt-session", session.token)
+
+	response, err := session.client.Do(request)
+	if err != nil {
+		t.Logf("diagnostics: ziti %s query error: %v", label, err)
+		return
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Logf("diagnostics: ziti %s read error: %v", label, err)
+		return
+	}
+	trimmedBody := strings.TrimSpace(string(body))
+	if trimmedBody == "" {
+		trimmedBody = "{}"
+	}
+	t.Logf("diagnostics: ziti %s status=%d body=%s", label, response.StatusCode, truncateLogLine(trimmedBody))
+}

--- a/suites/go-core/tests/ziti_diagnostics_test.go
+++ b/suites/go-core/tests/ziti_diagnostics_test.go
@@ -18,16 +18,19 @@ import (
 )
 
 const (
-	zitiDiagnosticsTimeout        = 20 * time.Second
-	zitiDiagnosticsRequestTimeout = 15 * time.Second
-	zitiMgmtEndpointEnvKey        = "ZITI_MGMT_ENDPOINT"
-	zitiMgmtServiceName           = "ziti-mgmt"
-	zitiMgmtPath                  = "/edge/management/v1"
+	zitiDiagnosticsTimeout                = 20 * time.Second
+	zitiDiagnosticsRequestTimeout         = 15 * time.Second
+	zitiMgmtEndpointEnvKey                = "ZITI_MGMT_ENDPOINT"
+	zitiMgmtServiceName                   = "ziti-mgmt"
+	zitiMgmtPath                          = "/edge/management/v1"
+	zitiDiagnosticsSecretNamespaceEnvKey  = "ZITI_DIAGNOSTICS_SECRET_NAMESPACE"
+	zitiDiagnosticsSecretNameEnvKey       = "ZITI_DIAGNOSTICS_SECRET_NAME"
+	zitiDiagnosticsDefaultSecretNamespace = "platform"
 	// DEV/E2E ONLY: ziti-diagnostics must only exist in dev/E2E bootstrap
 	// deployments and must never be enabled in production.
-	zitiDiagnosticsSecretName  = "ziti-diagnostics"
-	zitiDiagnosticsUserKey     = "username"
-	zitiDiagnosticsPasswordKey = "password"
+	zitiDiagnosticsDefaultSecretName = "ziti-diagnostics"
+	zitiDiagnosticsUserKey           = "username"
+	zitiDiagnosticsPasswordKey       = "password"
 )
 
 type zitiDiagnosticsQuery struct {
@@ -69,24 +72,31 @@ func TestZitiManagementEndpointExplicitOverride(t *testing.T) {
 	}
 }
 
-func TestZitiDiagnosticsSecretUsesPlatformNamespace(t *testing.T) {
+func TestZitiDiagnosticsSecretUsesBootstrapDefaults(t *testing.T) {
+	t.Setenv(zitiDiagnosticsSecretNamespaceEnvKey, "")
+	t.Setenv(zitiDiagnosticsSecretNameEnvKey, "")
+	t.Setenv("E2E_NAMESPACE", "custom-e2e")
+	t.Setenv("DEVSPACE_NAMESPACE", "custom-devspace")
+
 	secretNamespace, secretName := zitiDiagnosticsSecretRef()
-	if secretNamespace != "platform" {
-		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "platform")
+	if secretNamespace != zitiDiagnosticsDefaultSecretNamespace {
+		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, zitiDiagnosticsDefaultSecretNamespace)
 	}
-	if secretName != zitiDiagnosticsSecretName {
-		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsSecretName)
+	if secretName != zitiDiagnosticsDefaultSecretName {
+		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsDefaultSecretName)
 	}
 }
 
-func TestZitiDiagnosticsSecretUsesDevspaceNamespace(t *testing.T) {
-	t.Setenv("DEVSPACE_NAMESPACE", "custom-platform")
+func TestZitiDiagnosticsSecretUsesExplicitOverrides(t *testing.T) {
+	t.Setenv(zitiDiagnosticsSecretNamespaceEnvKey, "custom-platform")
+	t.Setenv(zitiDiagnosticsSecretNameEnvKey, "custom-ziti-diagnostics")
+
 	secretNamespace, secretName := zitiDiagnosticsSecretRef()
 	if secretNamespace != "custom-platform" {
 		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "custom-platform")
 	}
-	if secretName != zitiDiagnosticsSecretName {
-		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsSecretName)
+	if secretName != "custom-ziti-diagnostics" {
+		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, "custom-ziti-diagnostics")
 	}
 }
 
@@ -198,7 +208,9 @@ func zitiDiagnosticsCredentials(t *testing.T, ctx context.Context) (string, stri
 }
 
 func zitiDiagnosticsSecretRef() (string, string) {
-	return envOrDefault("E2E_NAMESPACE", envOrDefault("DEVSPACE_NAMESPACE", "platform")), zitiDiagnosticsSecretName
+	namespace := envOrDefault(zitiDiagnosticsSecretNamespaceEnvKey, zitiDiagnosticsDefaultSecretNamespace)
+	name := envOrDefault(zitiDiagnosticsSecretNameEnvKey, zitiDiagnosticsDefaultSecretName)
+	return namespace, name
 }
 
 func zitiManagementEndpoint() string {


### PR DESCRIPTION
## Summary

- Replaces expose-specific Ziti diagnostics credential handling with a shared Go E2E diagnostics helper.
- Uses the generic `ziti-diagnostics` secret and documents it as DEV/E2E-only.
- Defaults the secret reference to bootstrap-managed `platform/ziti-diagnostics` instead of deriving from `E2E_NAMESPACE` or `DEVSPACE_NAMESPACE`.
- Adds explicit `ZITI_DIAGNOSTICS_SECRET_NAMESPACE` and `ZITI_DIAGNOSTICS_SECRET_NAME` overrides plus tests for default and override behavior.
- Keeps expose-specific queries as callers of the shared helper, while adding reusable default Ziti dumps.
- Updates the go-core runner to invoke the shared Ziti diagnostics dump after failed suite runs.

## Related

Follow-up to merged PR #180. Complements agynio/bootstrap#544.

Fixes #170

## Test & Lint Summary

- `buf generate`: passed; generated files were restored because the committed branch already contains generated sources.
- `CGO_ENABLED=0 go test -run 'TestZitiManagementEndpoint|TestZitiDiagnosticsSecret|TestZitiDiagnosticsDump' -tags 'e2e svc_agents_orchestrator' ./tests/...`: 4 passed / 0 failed / 1 skipped; tracecanary had no test files.
- `gofmt -w tests/ziti_diagnostics_test.go tests/expose_test.go`: passed with no formatting errors.
- `test -z "$(gofmt -l tests/ziti_diagnostics_test.go tests/expose_test.go)"`: passed; lint/format check reported no errors.
