### PR TITLE
fix(e2e): cover ziti diagnostics namespace precedence

### DIFF
--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -72,6 +72,8 @@ func TestZitiManagementEndpointExplicitOverride(t *testing.T) {
 }
 
 func TestZitiDiagnosticsSecretUsesPlatformNamespace(t *testing.T) {
+	t.Setenv("E2E_NAMESPACE", "")
+	t.Setenv("DEVSPACE_NAMESPACE", "")
 	secretNamespace, secretName := zitiDiagnosticsSecretRef()
 	if secretNamespace != "platform" {
 		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "platform")
@@ -82,10 +84,23 @@ func TestZitiDiagnosticsSecretUsesPlatformNamespace(t *testing.T) {
 }
 
 func TestZitiDiagnosticsSecretUsesDevspaceNamespace(t *testing.T) {
+	t.Setenv("E2E_NAMESPACE", "")
 	t.Setenv("DEVSPACE_NAMESPACE", "custom-platform")
 	secretNamespace, secretName := zitiDiagnosticsSecretRef()
 	if secretNamespace != "custom-platform" {
 		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "custom-platform")
+	}
+	if secretName != zitiDiagnosticsSecretName {
+		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsSecretName)
+	}
+}
+
+func TestZitiDiagnosticsSecretPrefersE2ENamespace(t *testing.T) {
+	t.Setenv("E2E_NAMESPACE", "e2e-platform")
+	t.Setenv("DEVSPACE_NAMESPACE", "custom-platform")
+	secretNamespace, secretName := zitiDiagnosticsSecretRef()
+	if secretNamespace != "e2e-platform" {
+		t.Fatalf("ziti diagnostics secret namespace mismatch: got %q want %q", secretNamespace, "e2e-platform")
 	}
 	if secretName != zitiDiagnosticsSecretName {
 		t.Fatalf("ziti diagnostics secret name mismatch: got %q want %q", secretName, zitiDiagnosticsSecretName)


### PR DESCRIPTION
## Summary

- Clears `E2E_NAMESPACE` in the `DEVSPACE_NAMESPACE` fallback test so CI's default E2E namespace does not mask the fallback path.
- Adds explicit coverage that `E2E_NAMESPACE` takes precedence over `DEVSPACE_NAMESPACE` when both are set.

## Related

Fixes agynio/agents-orchestrator#202

## Test & Lint Summary

- `buf generate`: passed; generated output was restored because this minimal PR does not require committed generated changes.
- `go test -tags 'e2e svc_agents_orchestrator' ./tests -run 'TestZitiDiagnosticsSecret(UsesPlatformNamespace|UsesDevspaceNamespace|PrefersE2ENamespace)$' -count=1 -v`: 3 passed / 0 failed / 0 skipped.
- `test -z "$(gofmt -l suites/go-core/tests/expose_test.go)"`: passed; lint/format check reported no errors.
- `git diff --check`: passed; no whitespace errors.