### PR TITLE
fix(e2e): pin agent init images

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -169,7 +169,7 @@ runs:
         fi
 
         if [ -z "${CODEX_INIT_IMAGE:-}" ]; then
-          CODEX_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:latest"
+          CODEX_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:0.13.27"
           echo "CODEX_INIT_IMAGE=$CODEX_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 
@@ -180,17 +180,17 @@ runs:
         fi
 
         if [ -z "${AGN_INIT_IMAGE:-}" ]; then
-          AGN_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:latest"
+          AGN_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.5.4"
           echo "AGN_INIT_IMAGE=$AGN_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 
         if [ -z "${CLAUDE_INIT_IMAGE:-}" ]; then
-          CLAUDE_INIT_IMAGE="ghcr.io/agynio/agent-init-claude:latest"
+          CLAUDE_INIT_IMAGE="ghcr.io/agynio/agent-init-claude:0.1.27"
           echo "CLAUDE_INIT_IMAGE=$CLAUDE_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 
         if [ -z "${AGN_EXPOSE_INIT_IMAGE:-}" ]; then
-          AGN_EXPOSE_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:latest"
+          AGN_EXPOSE_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.5.4"
           echo "AGN_EXPOSE_INIT_IMAGE=$AGN_EXPOSE_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 

--- a/.github/workflows/agn-cli-e2e.yml
+++ b/.github/workflows/agn-cli-e2e.yml
@@ -13,10 +13,10 @@ jobs:
       contents: read
     env:
       AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
-      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
-      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
-      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
-      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.27
+      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.4
+      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.27
+      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,10 +17,10 @@ jobs:
       contents: read
     env:
       AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
-      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
-      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
-      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
-      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.27
+      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.4
+      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.27
+      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.4
       TF_VAR_threads_chart_version: 0.4.12
       TF_VAR_threads_image_tag: 0.4.12
     steps:

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -257,7 +257,7 @@ func setupExposeTestWorkload(t *testing.T) exposeWorkloadFixture {
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:latest")
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.5.4")
 
 	setup := newWorkflowGatewaySetup(t, ctx)
 	identityID := setup.IdentityID

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -58,9 +58,9 @@ var (
 	runnersAddr     = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr     = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr     = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage  = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:latest")
-	agnInitImage    = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:latest")
-	claudeInitImage = envOrDefault("CLAUDE_INIT_IMAGE", "ghcr.io/agynio/agent-init-claude:latest")
+	codexInitImage  = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.27")
+	agnInitImage    = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.5.4")
+	claudeInitImage = envOrDefault("CLAUDE_INIT_IMAGE", "ghcr.io/agynio/agent-init-claude:0.1.27")
 )
 
 type pipelineRun struct {

--- a/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
@@ -14,7 +14,7 @@ const createAgentOptions = {
   description: 'description',
   configuration: '{}',
   image: 'alpine:3.21',
-  initImage: 'ghcr.io/agynio/agent-init-codex:latest',
+  initImage: 'ghcr.io/agynio/agent-init-codex:0.13.27',
 };
 
 test.describe('chat api helpers', () => {
@@ -40,7 +40,7 @@ test.describe('chat api helpers', () => {
     const payload = buildCreateAgentRequestBytes(createAgentOptions);
 
     expect(Buffer.from(payload).toString('hex')).toBe(
-      '0a0a6167656e742d6e616d651209617373697374616e741a086d6f64656c2d6964220b6465736372697074696f6e2a027b7d320b616c70696e653a332e3231420f6f7267616e697a6174696f6e2d69644a26676863722e696f2f6167796e696f2f6167656e742d696e69742d636f6465783a6c61746573746801',
+      '0a0a6167656e742d6e616d651209617373697374616e741a086d6f64656c2d6964220b6465736372697074696f6e2a027b7d320b616c70696e653a332e3231420f6f7267616e697a6174696f6e2d69644a27676863722e696f2f6167796e696f2f6167656e742d696e69742d636f6465783a302e31332e32376801',
     );
   });
 

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -12,7 +12,7 @@ const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
 export const DEFAULT_TEST_INIT_IMAGE =
   process.env.E2E_AGENT_INIT_IMAGE?.trim() ||
   process.env.CODEX_INIT_IMAGE?.trim() ||
-  'ghcr.io/agynio/agent-init-codex:latest';
+    'ghcr.io/agynio/agent-init-codex:0.13.27';
 export const DEFAULT_TEST_AGENT_IMAGE = 'alpine:3.21';
 
 const CONNECT_JSON_HEADERS = {

--- a/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
@@ -15,7 +15,7 @@ const CODEX_TEST_LLM_ENDPOINT =
   process.env.E2E_TEST_LLM_ENDPOINT ?? 'https://testllm.dev/v1/org/agynio/suite/codex/responses';
 const CLAUDE_TEST_LLM_ENDPOINT =
   process.env.E2E_TEST_LLM_ENDPOINT_CLAUDE ?? 'https://testllm.dev/v1/org/agynio/suite/claude/messages';
-const CLAUDE_INIT_IMAGE = process.env.CLAUDE_INIT_IMAGE ?? 'ghcr.io/agynio/agent-init-claude:latest';
+const CLAUDE_INIT_IMAGE = process.env.CLAUDE_INIT_IMAGE ?? 'ghcr.io/agynio/agent-init-claude:0.1.27';
 const CLAUDE_PROTOCOL = 'PROTOCOL_ANTHROPIC_MESSAGES';
 const MESSAGE_DEEP_LINK_RESOLUTION_TIMEOUT_MS = 180000;
 const MESSAGE_DEEP_LINK_POLL_INTERVAL_MS = 5000;

--- a/suites/playwright-tracing-app/test/e2e/gateway-api.spec.ts
+++ b/suites/playwright-tracing-app/test/e2e/gateway-api.spec.ts
@@ -10,7 +10,7 @@ const createAgentOptions = {
   description: 'description',
   configuration: '{}',
   image: 'alpine:3.21',
-  initImage: 'ghcr.io/agynio/agent-init-agn:latest',
+  initImage: 'ghcr.io/agynio/agent-init-agn:0.5.4',
 };
 
 test.describe('tracing gateway api helpers', () => {
@@ -36,7 +36,7 @@ test.describe('tracing gateway api helpers', () => {
     const payload = buildCreateAgentRequestBytes(createAgentOptions);
 
     expect(Buffer.from(payload).toString('hex')).toBe(
-      '0a0a6167656e742d6e616d651209617373697374616e741a086d6f64656c2d6964220b6465736372697074696f6e2a027b7d320b616c70696e653a332e3231420f6f7267616e697a6174696f6e2d69644a24676863722e696f2f6167796e696f2f6167656e742d696e69742d61676e3a6c61746573746801',
+      '0a0a6167656e742d6e616d651209617373697374616e741a086d6f64656c2d6964220b6465736372697074696f6e2a027b7d320b616c70696e653a332e3231420f6f7267616e697a6174696f6e2d69644a23676863722e696f2f6167796e696f2f6167656e742d696e69742d61676e3a302e352e346801',
     );
   });
 });

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -36,9 +36,9 @@ const TEST_LLM_MODEL = 'mcp-tools-test';
 const AGENT_IMAGE = 'alpine:3.21';
 const MCP_IMAGE = 'node:22-slim';
 const DEFAULT_INIT_IMAGES: Record<TraceSdk, string> = {
-  agn: 'ghcr.io/agynio/agent-init-agn:latest',
-  codex: 'ghcr.io/agynio/agent-init-codex:latest',
-  claude: 'ghcr.io/agynio/agent-init-claude:latest',
+  agn: 'ghcr.io/agynio/agent-init-agn:0.5.4',
+  codex: 'ghcr.io/agynio/agent-init-codex:0.13.27',
+  claude: 'ghcr.io/agynio/agent-init-claude:0.1.27',
 };
 const INIT_IMAGE_ENV_VARS: Record<TraceSdk, string> = {
   agn: 'AGN_INIT_IMAGE',


### PR DESCRIPTION
## Summary
- Pin centralized E2E agent init image defaults to immutable release tags instead of mutable `latest`/minor tags.
- Update suite-local fallback images and helper fixture expectations for Codex, Claude, AGN, and expose lifecycle tests.
- Keeps agynio/agents-orchestrator#207 as the cross-repo tracker for the red agents-orchestrator E2E.

Closes #184

## Related
- agynio/agents-orchestrator#207
- agynio/agent-init-claude#46
- agynio/expose#31

## Test & Lint Summary
- `docker manifest inspect ghcr.io/agynio/agent-init-codex:0.13.27`: passed
- `docker manifest inspect ghcr.io/agynio/agent-init-claude:0.1.27`: passed
- `docker manifest inspect ghcr.io/agynio/agent-init-agn:0.5.4`: passed
- `GOTOOLCHAIN=go1.25.7 go test ./...` from `suites/go-core`: 1 package passed, 0 failed, 0 skipped; 2 packages had no test files
- `npm ci && npx buf generate ... && npm run typecheck` from `suites/playwright-tracing-app`: passed
- `npm ci && npx buf generate ... && npx tsc --noEmit -p tsconfig.json` from `suites/playwright-chat-app`: passed
- `E2E_BASE_URL=http://127.0.0.1 npx playwright test test/e2e/chat-api.spec.ts`: 6 passed, 0 failed, 0 skipped
- `E2E_BASE_URL=http://127.0.0.1 npx playwright test test/e2e/gateway-api.spec.ts`: 3 passed, 0 failed, 0 skipped
- `git diff --check`: passed
- Lint note: `npx eslint ...` is currently blocked because `eslint.config.js` imports ESLint packages that are not declared in `package.json`/lockfile; no code lint errors were produced before dependency resolution failed.