### PR TITLE
fix(e2e): pin agn init image 0.5.5

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -180,7 +180,7 @@ runs:
         fi
 
         if [ -z "${AGN_INIT_IMAGE:-}" ]; then
-          AGN_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.5.4"
+          AGN_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.5.5"
           echo "AGN_INIT_IMAGE=$AGN_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 
@@ -190,7 +190,7 @@ runs:
         fi
 
         if [ -z "${AGN_EXPOSE_INIT_IMAGE:-}" ]; then
-          AGN_EXPOSE_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.5.4"
+          AGN_EXPOSE_INIT_IMAGE="ghcr.io/agynio/agent-init-agn:0.5.5"
           echo "AGN_EXPOSE_INIT_IMAGE=$AGN_EXPOSE_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 

--- a/.github/workflows/agn-cli-e2e.yml
+++ b/.github/workflows/agn-cli-e2e.yml
@@ -14,9 +14,9 @@ jobs:
     env:
       AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
       CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.27
-      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.4
+      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.5
       CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.27
-      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.4
+      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,9 +18,9 @@ jobs:
     env:
       AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
       CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.27
-      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.4
+      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.5
       CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.27
-      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.4
+      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.5
       TF_VAR_threads_chart_version: 0.4.12
       TF_VAR_threads_image_tag: 0.4.12
     steps:

--- a/suites/go-core/tests/expose_test.go
+++ b/suites/go-core/tests/expose_test.go
@@ -257,7 +257,7 @@ func setupExposeTestWorkload(t *testing.T) exposeWorkloadFixture {
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.5.4")
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.5.5")
 
 	setup := newWorkflowGatewaySetup(t, ctx)
 	identityID := setup.IdentityID

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -59,7 +59,7 @@ var (
 	secretsAddr     = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr     = envOrDefault("TRACING_ADDRESS", "tracing:50051")
 	codexInitImage  = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.27")
-	agnInitImage    = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.5.4")
+	agnInitImage    = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.5.5")
 	claudeInitImage = envOrDefault("CLAUDE_INIT_IMAGE", "ghcr.io/agynio/agent-init-claude:0.1.27")
 )
 

--- a/suites/playwright-tracing-app/test/e2e/gateway-api.spec.ts
+++ b/suites/playwright-tracing-app/test/e2e/gateway-api.spec.ts
@@ -10,7 +10,7 @@ const createAgentOptions = {
   description: 'description',
   configuration: '{}',
   image: 'alpine:3.21',
-  initImage: 'ghcr.io/agynio/agent-init-agn:0.5.4',
+  initImage: 'ghcr.io/agynio/agent-init-agn:0.5.5',
 };
 
 test.describe('tracing gateway api helpers', () => {

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -36,7 +36,7 @@ const TEST_LLM_MODEL = 'mcp-tools-test';
 const AGENT_IMAGE = 'alpine:3.21';
 const MCP_IMAGE = 'node:22-slim';
 const DEFAULT_INIT_IMAGES: Record<TraceSdk, string> = {
-  agn: 'ghcr.io/agynio/agent-init-agn:0.5.4',
+  agn: 'ghcr.io/agynio/agent-init-agn:0.5.5',
   codex: 'ghcr.io/agynio/agent-init-codex:0.13.27',
   claude: 'ghcr.io/agynio/agent-init-claude:0.1.27',
 };


### PR DESCRIPTION
## Summary

- Pin centralized AGN init defaults from `agent-init-agn:0.5.4` to `agent-init-agn:0.5.5`.
- Applies both AGN runtime and expose-specific init image paths.
- Fixes agynio/e2e#186 and supports agynio/agents-orchestrator#207 E2E tracking.

## Validation

- `docker manifest inspect ghcr.io/agynio/agent-init-agn:0.5.5`
- `GOTOOLCHAIN=go1.25.7 go test ./...` from `suites/go-core`
- `npm ci` from `suites/playwright-tracing-app`
- `npm run typecheck` from `suites/playwright-tracing-app`
- `git diff --check`

## Test & Lint Summary

- Tests: `GOTOOLCHAIN=go1.25.7 go test ./...` — 1 package passed, 0 failed, 0 skipped; 2 packages reported no test files.
- Typecheck: `npm run typecheck` — passed.
- Lint/static checks: `git diff --check` passed with no whitespace errors.