### PR TITLE
fix(e2e): pin message id init images

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -169,7 +169,7 @@ runs:
         fi
 
         if [ -z "${CODEX_INIT_IMAGE:-}" ]; then
-          CODEX_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:0.13.28"
+          CODEX_INIT_IMAGE="ghcr.io/agynio/agent-init-codex:0.13.29"
           echo "CODEX_INIT_IMAGE=$CODEX_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 
@@ -185,7 +185,7 @@ runs:
         fi
 
         if [ -z "${CLAUDE_INIT_IMAGE:-}" ]; then
-          CLAUDE_INIT_IMAGE="ghcr.io/agynio/agent-init-claude:0.1.28"
+          CLAUDE_INIT_IMAGE="ghcr.io/agynio/agent-init-claude:0.1.29"
           echo "CLAUDE_INIT_IMAGE=$CLAUDE_INIT_IMAGE" >> "$GITHUB_ENV"
         fi
 

--- a/.github/workflows/agn-cli-e2e.yml
+++ b/.github/workflows/agn-cli-e2e.yml
@@ -13,9 +13,9 @@ jobs:
       contents: read
     env:
       AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
-      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.28
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.29
       AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.5
-      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.28
+      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.29
       AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.5
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,9 +17,9 @@ jobs:
       contents: read
     env:
       AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
-      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.28
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.29
       AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.5
-      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.28
+      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.29
       AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.5
       TF_VAR_threads_chart_version: 0.4.12
       TF_VAR_threads_image_tag: 0.4.12

--- a/suites/go-core/tests/main_test.go
+++ b/suites/go-core/tests/main_test.go
@@ -58,9 +58,9 @@ var (
 	runnersAddr     = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr     = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr     = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage  = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.28")
+	codexInitImage  = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.29")
 	agnInitImage    = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.5.5")
-	claudeInitImage = envOrDefault("CLAUDE_INIT_IMAGE", "ghcr.io/agynio/agent-init-claude:0.1.28")
+	claudeInitImage = envOrDefault("CLAUDE_INIT_IMAGE", "ghcr.io/agynio/agent-init-claude:0.1.29")
 )
 
 type pipelineRun struct {

--- a/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.spec.ts
@@ -14,7 +14,7 @@ const createAgentOptions = {
   description: 'description',
   configuration: '{}',
   image: 'alpine:3.21',
-  initImage: 'ghcr.io/agynio/agent-init-codex:0.13.28',
+  initImage: 'ghcr.io/agynio/agent-init-codex:0.13.29',
 };
 
 test.describe('chat api helpers', () => {

--- a/suites/playwright-chat-app/test/e2e/chat-api.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-api.ts
@@ -12,7 +12,7 @@ const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
 export const DEFAULT_TEST_INIT_IMAGE =
   process.env.E2E_AGENT_INIT_IMAGE?.trim() ||
   process.env.CODEX_INIT_IMAGE?.trim() ||
-    'ghcr.io/agynio/agent-init-codex:0.13.28';
+    'ghcr.io/agynio/agent-init-codex:0.13.29';
 export const DEFAULT_TEST_AGENT_IMAGE = 'alpine:3.21';
 
 const CONNECT_JSON_HEADERS = {

--- a/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
+++ b/suites/playwright-chat-app/test/e2e/chat-trace-link.spec.ts
@@ -15,7 +15,7 @@ const CODEX_TEST_LLM_ENDPOINT =
   process.env.E2E_TEST_LLM_ENDPOINT ?? 'https://testllm.dev/v1/org/agynio/suite/codex/responses';
 const CLAUDE_TEST_LLM_ENDPOINT =
   process.env.E2E_TEST_LLM_ENDPOINT_CLAUDE ?? 'https://testllm.dev/v1/org/agynio/suite/claude/messages';
-const CLAUDE_INIT_IMAGE = process.env.CLAUDE_INIT_IMAGE ?? 'ghcr.io/agynio/agent-init-claude:0.1.28';
+const CLAUDE_INIT_IMAGE = process.env.CLAUDE_INIT_IMAGE ?? 'ghcr.io/agynio/agent-init-claude:0.1.29';
 const CLAUDE_PROTOCOL = 'PROTOCOL_ANTHROPIC_MESSAGES';
 const MESSAGE_DEEP_LINK_RESOLUTION_TIMEOUT_MS = 180000;
 const MESSAGE_DEEP_LINK_POLL_INTERVAL_MS = 5000;

--- a/suites/playwright-tracing-app/test/e2e/tracing-run.ts
+++ b/suites/playwright-tracing-app/test/e2e/tracing-run.ts
@@ -37,8 +37,8 @@ const AGENT_IMAGE = 'alpine:3.21';
 const MCP_IMAGE = 'node:22-slim';
 const DEFAULT_INIT_IMAGES: Record<TraceSdk, string> = {
   agn: 'ghcr.io/agynio/agent-init-agn:0.5.5',
-  codex: 'ghcr.io/agynio/agent-init-codex:0.13.28',
-  claude: 'ghcr.io/agynio/agent-init-claude:0.1.28',
+  codex: 'ghcr.io/agynio/agent-init-codex:0.13.29',
+  claude: 'ghcr.io/agynio/agent-init-claude:0.1.29',
 };
 const INIT_IMAGE_ENV_VARS: Record<TraceSdk, string> = {
   agn: 'AGN_INIT_IMAGE',


### PR DESCRIPTION
## Summary

- Pin Codex init defaults to `ghcr.io/agynio/agent-init-codex:0.13.29`.
- Pin Claude init defaults to `ghcr.io/agynio/agent-init-claude:0.1.29`.
- These images include `agynd v0.14.18` from agynio/agynd-cli#136 for span-level message-id tracing correlation.

Refs #192
Tracks agynio/agents-orchestrator#207.

## Validation

- `git diff --check`
- `cd suites/go-core && GOTOOLCHAIN=go1.25.7 go test ./...`
- `cd suites/playwright-tracing-app && npm run typecheck`
- Release verified: agynio/agynd-cli v0.14.18 https://github.com/agynio/agynd-cli/actions/runs/26917070321
- Release verified: agynio/agent-init-codex v0.13.29 https://github.com/agynio/agent-init-codex/actions/runs/26917227519
- Release verified: agynio/agent-init-claude v0.1.29 https://github.com/agynio/agent-init-claude/actions/runs/26917227917