### PR TITLE
test(console): cover navigation crash paths

### DIFF
--- a/docs/e2e/suites/playwright.md
+++ b/docs/e2e/suites/playwright.md
@@ -13,7 +13,7 @@ Validates Console App user journeys and browser-visible API behaviors for sign-i
 
 - Source directory: `suites/playwright`
 - Test inventory pattern: `test/e2e/*.spec.ts`
-- Included case count: 41
+- Included case count: 44
 
 ## Actors
 
@@ -82,6 +82,8 @@ Validates Console App user journeys and browser-visible API behaviors for sign-i
 | [E2E-PLAYWRIGHT-040](#e2e-playwright-040) | `lists users` | @svc_console |
 | [E2E-PLAYWRIGHT-041](#e2e-playwright-041) | `shows user detail` | @svc_console |
 | [E2E-PLAYWRIGHT-042](#e2e-playwright-042) | `workloads header lays out across columns` | @svc_console, @svc_gateway, @smoke |
+| [E2E-PLAYWRIGHT-043](#e2e-playwright-043) | `opens every platform sidebar section without browser crashes` | @svc_console, @svc_gateway, @smoke |
+| [E2E-PLAYWRIGHT-044](#e2e-playwright-044) | `opens every organization sidebar section without browser crashes` | @svc_console, @svc_gateway, @smoke |
 
 ## Scenarios
 
@@ -576,3 +578,27 @@ Validates Console App user journeys and browser-visible API behaviors for sign-i
 - **Given** An organization activity workloads page is available.
 - **When** The user opens the workloads page.
 - **Then** The Agent and Status headers are visible and aligned in separate columns.
+
+### E2E-PLAYWRIGHT-043
+
+- **Source:** `suites/playwright/test/e2e/console-navigation.spec.ts`
+- **Test:** `opens every platform sidebar section without browser crashes`
+- **Tags:** @svc_console, @svc_gateway, @smoke
+
+**Scenario:** opens every platform sidebar section without browser crashes
+
+- **Given** The user is signed in as a cluster administrator.
+- **When** The user opens each platform sidebar section.
+- **Then** The Console shell remains mounted and no browser page crash is reported.
+
+### E2E-PLAYWRIGHT-044
+
+- **Source:** `suites/playwright/test/e2e/console-navigation.spec.ts`
+- **Test:** `opens every organization sidebar section without browser crashes`
+- **Tags:** @svc_console, @svc_gateway, @smoke
+
+**Scenario:** opens every organization sidebar section without browser crashes
+
+- **Given** The user is signed in and an organization is selected.
+- **When** The user opens each organization sidebar section, including Runners.
+- **Then** The Console shell remains mounted and no TooltipProvider page crash is reported.

--- a/suites/playwright/test/e2e/console-navigation.spec.ts
+++ b/suites/playwright/test/e2e/console-navigation.spec.ts
@@ -4,6 +4,7 @@ import { createOrganization, setSelectedOrganization } from './console-api';
 
 const TOOLTIP_PROVIDER_ERROR = '`Tooltip` must be used within `TooltipProvider`';
 const APP_READY_TIMEOUT_MS = 15000;
+const ROUTE_SETTLE_TIMEOUT_MS = 500;
 
 type NavigationTarget = {
   navTestId: string;
@@ -61,7 +62,10 @@ function collectCrashSignals(page: Page): string[] {
 }
 
 async function expectNoCrashSignals(crashSignals: string[], target: NavigationTarget): Promise<void> {
-  expect(crashSignals, `unexpected browser crash signals after opening ${target.title}`).toEqual([]);
+  await test.step(`assert no crash signals after ${target.title}`, async () => {
+    await new Promise((resolve) => setTimeout(resolve, ROUTE_SETTLE_TIMEOUT_MS));
+    expect(crashSignals, `unexpected browser crash signals after opening ${target.title}`).toEqual([]);
+  });
 }
 
 async function expectShellReady(page: Page, target: NavigationTarget): Promise<void> {
@@ -71,7 +75,6 @@ async function expectShellReady(page: Page, target: NavigationTarget): Promise<v
 }
 
 async function openNavigationTarget(page: Page, target: NavigationTarget, crashSignals: string[]): Promise<void> {
-  crashSignals.length = 0;
   await page.getByTestId(target.navTestId).click();
   await expectShellReady(page, target);
   await expectNoCrashSignals(crashSignals, target);

--- a/suites/playwright/test/e2e/console-navigation.spec.ts
+++ b/suites/playwright/test/e2e/console-navigation.spec.ts
@@ -1,0 +1,106 @@
+import type { ConsoleMessage, Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import { createOrganization, setSelectedOrganization } from './console-api';
+
+const TOOLTIP_PROVIDER_ERROR = '`Tooltip` must be used within `TooltipProvider`';
+const APP_READY_TIMEOUT_MS = 15000;
+
+type NavigationTarget = {
+  navTestId: string;
+  title: string;
+  pathPattern: RegExp;
+};
+
+const platformTargets: NavigationTarget[] = [
+  { navTestId: 'nav-dashboard', title: 'Dashboard', pathPattern: /\/$/ },
+  { navTestId: 'nav-users', title: 'Users', pathPattern: /\/users$/ },
+  { navTestId: 'nav-organizations', title: 'Organizations', pathPattern: /\/organizations$/ },
+  { navTestId: 'nav-cluster-runners', title: 'Cluster Runners', pathPattern: /\/runners$/ },
+  { navTestId: 'nav-apps', title: 'Apps', pathPattern: /\/apps$/ },
+];
+
+const organizationTargets: NavigationTarget[] = [
+  { navTestId: 'nav-organization-overview', title: 'Overview', pathPattern: /\/organizations\/[^/]+$/ },
+  { navTestId: 'nav-organization-members', title: 'Members', pathPattern: /\/organizations\/[^/]+\/members$/ },
+  { navTestId: 'nav-organization-agents', title: 'Agents', pathPattern: /\/organizations\/[^/]+\/agents$/ },
+  { navTestId: 'nav-organization-volumes', title: 'Volumes', pathPattern: /\/organizations\/[^/]+\/volumes$/ },
+  { navTestId: 'nav-organization-runners', title: 'Runners', pathPattern: /\/organizations\/[^/]+\/runners$/ },
+  { navTestId: 'nav-organization-apps', title: 'Apps', pathPattern: /\/organizations\/[^/]+\/apps$/ },
+  { navTestId: 'nav-organization-llm-providers', title: 'LLM Providers', pathPattern: /\/organizations\/[^/]+\/llm-providers$/ },
+  { navTestId: 'nav-organization-models', title: 'Models', pathPattern: /\/organizations\/[^/]+\/models$/ },
+  { navTestId: 'nav-organization-secret-providers', title: 'Secret Providers', pathPattern: /\/organizations\/[^/]+\/secret-providers$/ },
+  { navTestId: 'nav-organization-secrets', title: 'Secrets', pathPattern: /\/organizations\/[^/]+\/secrets$/ },
+  { navTestId: 'nav-organization-image-pull-secrets', title: 'Image Pull Secrets', pathPattern: /\/organizations\/[^/]+\/image-pull-secrets$/ },
+  { navTestId: 'nav-organization-workloads', title: 'Workloads', pathPattern: /\/organizations\/[^/]+\/activity\/workloads$/ },
+  { navTestId: 'nav-organization-storage', title: 'Storage', pathPattern: /\/organizations\/[^/]+\/activity\/storage$/ },
+  { navTestId: 'nav-organization-threads', title: 'Threads', pathPattern: /\/organizations\/[^/]+\/threads$/ },
+  { navTestId: 'nav-organization-usage', title: 'Usage', pathPattern: /\/organizations\/[^/]+\/usage$/ },
+];
+
+function formatConsoleMessage(message: ConsoleMessage): string {
+  return `[${message.type()}] ${message.text()}`;
+}
+
+function collectCrashSignals(page: Page): string[] {
+  const crashSignals: string[] = [];
+
+  page.on('pageerror', (error) => {
+    crashSignals.push(error.message);
+  });
+  page.on('console', (message) => {
+    const text = message.text();
+    if (text.includes(TOOLTIP_PROVIDER_ERROR)) {
+      crashSignals.push(formatConsoleMessage(message));
+    }
+  });
+  page.on('crash', () => {
+    crashSignals.push('Page crashed.');
+  });
+
+  return crashSignals;
+}
+
+async function expectNoCrashSignals(crashSignals: string[], target: NavigationTarget): Promise<void> {
+  expect(crashSignals, `unexpected browser crash signals after opening ${target.title}`).toEqual([]);
+}
+
+async function expectShellReady(page: Page, target: NavigationTarget): Promise<void> {
+  await expect(page).toHaveURL(target.pathPattern, { timeout: APP_READY_TIMEOUT_MS });
+  await expect(page.getByTestId('console-sidebar')).toBeVisible({ timeout: APP_READY_TIMEOUT_MS });
+  await expect(page.getByTestId('page-title')).toHaveText(target.title, { timeout: APP_READY_TIMEOUT_MS });
+}
+
+async function openNavigationTarget(page: Page, target: NavigationTarget, crashSignals: string[]): Promise<void> {
+  crashSignals.length = 0;
+  await page.getByTestId(target.navTestId).click();
+  await expectShellReady(page, target);
+  await expectNoCrashSignals(crashSignals, target);
+}
+
+test.describe('console navigation', { tag: ['@svc_console', '@svc_gateway', '@smoke'] }, () => {
+  test('opens every platform sidebar section without browser crashes', async ({ page }) => {
+    const crashSignals = collectCrashSignals(page);
+
+    await page.goto('/');
+    await expectShellReady(page, platformTargets[0]);
+    await expectNoCrashSignals(crashSignals, platformTargets[0]);
+
+    for (const target of platformTargets) {
+      await openNavigationTarget(page, target, crashSignals);
+    }
+  });
+
+  test('opens every organization sidebar section without browser crashes', async ({ page }) => {
+    const crashSignals = collectCrashSignals(page);
+    const organizationId = await createOrganization(page, `e2e-org-navigation-${Date.now()}`);
+    await setSelectedOrganization(page, organizationId);
+
+    await page.goto(`/organizations/${organizationId}`);
+    await expectShellReady(page, organizationTargets[0]);
+    await expectNoCrashSignals(crashSignals, organizationTargets[0]);
+
+    for (const target of organizationTargets) {
+      await openNavigationTarget(page, target, crashSignals);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds centralized Playwright coverage for every current Console platform sidebar target.
- Adds centralized Playwright coverage for every current Console organization sidebar target, including the organization Runners TooltipProvider regression path.
- Fails on browser page crashes/page errors and explicitly guards the TooltipProvider error string.
- Updates the Playwright BDD inventory.

## Coupled bootstrap PR
This test PR is coupled with agynio/bootstrap#557 for #196 because the current bootstrap pin still deploys the pre-fix Console build. The bootstrap PR bumps the pinned Console chart to `0.10.10`.

Closes #196 once the companion bootstrap PR also lands.

## Test & Lint Summary
- `cd /workspace/e2e/suites/playwright && npm ci --no-fund --no-audit`: dependency install succeeded.
- `cd /workspace/e2e/suites/playwright && npx buf generate && E2E_BASE_URL=https://console.agyn.dev npx tsc --noEmit`: typecheck passed with 0 errors.
- `cd /workspace/e2e && git diff --check`: lint/whitespace check passed with no errors.
- `cd /workspace/e2e && E2E_SUITES=playwright E2E_PLAYWRIGHT_TEST_ARGS='test/e2e/console-navigation.spec.ts' devspace run test-e2e --tag svc_console`: blocked before tests by missing valid kube config (`please make sure you have an existing valid kube config`).
- `cd /workspace/e2e/suites/playwright && E2E_BASE_URL=https://console.agyn.dev npx playwright test test/e2e/console-navigation.spec.ts --grep @svc_console`: 0 passed / 2 failed / 0 skipped; blocked by missing `AGYN_API_TOKEN` for admin setup after installing Playwright browser dependencies.