### PR TITLE
fix(e2e): use canonical gateway service names

### DIFF
--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -265,10 +265,10 @@ PY
         agents-orchestrator- \
         authorization- \
         chat- \
-        gateway-gateway- \
+        gateway- \
         k8s-runner- \
         llm- \
-        llm-proxy-llm-proxy- \
+        llm-proxy- \
         organizations- \
         runners- \
         threads- \
@@ -396,7 +396,7 @@ EOF
       exec_env+=("PROVIDER_BINARY=$workdir/.provider/terraform-provider-agyn")
     fi
 
-    gateway_internal_url="http://gateway-gateway.${namespace}.svc.cluster.local:8080"
+    gateway_internal_url="http://gateway.${namespace}.svc.cluster.local:8080"
     if [ -n "${AGYN_BASE_URL:-}" ]; then
       exec_env+=("AGYN_BASE_URL=${AGYN_BASE_URL}")
     else

--- a/suites/go-core/tests/llm_proxy_test.go
+++ b/suites/go-core/tests/llm_proxy_test.go
@@ -48,11 +48,11 @@ func TestLLMProxyURLExplicitOverride(t *testing.T) {
 }
 
 func TestLLMGatewayConnectEndpointPath(t *testing.T) {
-	t.Setenv(gatewayBaseURLEnvKey, "http://gateway-gateway.platform.svc.cluster.local:8080")
+	t.Setenv(gatewayBaseURLEnvKey, "http://gateway.platform.svc.cluster.local:8080")
 
 	require.Equal(
 		t,
-		"http://gateway-gateway.platform.svc.cluster.local:8080/agynio.api.gateway.v1.LLMGateway/CreateLLMProvider",
+		"http://gateway.platform.svc.cluster.local:8080/agynio.api.gateway.v1.LLMGateway/CreateLLMProvider",
 		gatewayLLMConnectEndpoint(t, "CreateLLMProvider"),
 	)
 }

--- a/suites/go-core/tests/media_proxy_helpers_test.go
+++ b/suites/go-core/tests/media_proxy_helpers_test.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	mediaProxyURL = envOrDefault("MEDIA_PROXY_URL", "http://media-proxy:8080")
-	gatewayURL    = envOrDefault("GATEWAY_URL", "http://gateway-gateway:8080")
+	gatewayURL    = envOrDefault("GATEWAY_URL", "http://gateway:8080")
 
 	accessToken      string
 	resolvedIdentity mediaProxyIdentity


### PR DESCRIPTION
## Summary
- Update E2E pipeline internal gateway URL to `gateway.<namespace>.svc.cluster.local`.
- Update go-core llm-proxy and media-proxy test defaults to canonical gateway service names.
- Update failure diagnostic pod-name patterns from duplicated deployment prefixes to canonical `gateway-` and `llm-proxy-`.

Companion update for agynio/bootstrap#555 and agynio/bootstrap#556.

## Test & Lint Summary
- `gofmt -w suites/go-core/tests/llm_proxy_test.go suites/go-core/tests/media_proxy_helpers_test.go`: passed with no formatting changes remaining
- `shellcheck scripts/run-pipeline.sh`: passed with no errors
- `cd suites/go-core && go test ./...`: passed
- `cd suites/go-agn-cli && go test ./...`: passed; no packages to test
- `cd suites/go-terraform && go test ./...`: passed
- `git diff --check`: passed with no whitespace errors
- `rg "gateway-gateway|llm-proxy-llm-proxy" .`: passed with no matches

Test statistics: Go package checks 3 passed / 0 failed / 0 skipped; go-agn-cli reported no packages to test.
Lint/format status: passed with no errors.