### PR TITLE
fix(playwright): force platform navigation context

### DIFF
--- a/suites/playwright/test/e2e/console-navigation.spec.ts
+++ b/suites/playwright/test/e2e/console-navigation.spec.ts
@@ -74,6 +74,13 @@ async function expectShellReady(page: Page, target: NavigationTarget): Promise<v
   await expect(page.getByTestId('page-title')).toHaveText(target.title, { timeout: APP_READY_TIMEOUT_MS });
 }
 
+async function setClusterContext(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.localStorage.setItem('console.contextMode', JSON.stringify({ mode: 'cluster' }));
+    window.localStorage.removeItem('console.selectedOrganization');
+  });
+}
+
 async function openNavigationTarget(page: Page, target: NavigationTarget, crashSignals: string[]): Promise<void> {
   await page.getByTestId(target.navTestId).click();
   await expectShellReady(page, target);
@@ -84,6 +91,7 @@ test.describe('console navigation', { tag: ['@svc_console', '@svc_gateway', '@sm
   test('opens every platform sidebar section without browser crashes', async ({ page }) => {
     const crashSignals = collectCrashSignals(page);
 
+    await setClusterContext(page);
     await page.goto('/');
     await expectShellReady(page, platformTargets[0]);
     await expectNoCrashSignals(crashSignals, platformTargets[0]);


### PR DESCRIPTION
## Summary
- Force `console.contextMode` to cluster before the platform sidebar navigation smoke test opens `/`.
- Clear the legacy selected-organization key so a prior org context cannot render the organization sidebar for platform navigation coverage.
- Keep organization sidebar navigation coverage unchanged.

Closes #199

Related: agynio/bootstrap#556

## Test & Lint Summary
- `cd suites/playwright && npm ci`: passed
- `cd suites/playwright && npx buf generate`: passed
- `cd suites/playwright && npm exec tsc -- --noEmit -p tsconfig.json`: passed
- `cd suites/playwright && E2E_BASE_URL=https://console.agyn.dev npm exec playwright -- test test/e2e/console-navigation.spec.ts --list`: passed; 2 tests discovered
- `git diff --check`: passed with no whitespace errors
- `rg "gateway-gateway|llm-proxy-llm-proxy" .`: passed with no matches

Test statistics: Playwright console-navigation discovery 2 passed / 0 failed / 0 skipped; TypeScript check passed.
Lint/format status: passed with no errors.