### PR TITLE
Gate Terraform egress provider tests

### DIFF
--- a/suites/go-terraform/tests/resource_egress_rule_test.go
+++ b/suites/go-terraform/tests/resource_egress_rule_test.go
@@ -4,13 +4,27 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+const agynTerraformEgressResourcesEnv = "AGYN_TF_EGRESS_RESOURCES"
+
+func skipUnlessTerraformEgressResourcesEnabled(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv(agynTerraformEgressResourcesEnv) != "1" {
+		// Remove this gate once agynio/terraform-provider-agyn#82 ships in a provider release.
+		t.Skip("agyn_egress_rule and agyn_egress_rule_attachment are pending provider support; see agynio/terraform-provider-agyn#82")
+	}
+}
+
 func TestAccAgynEgressRule_basic(t *testing.T) {
+	skipUnlessTerraformEgressResourcesEnabled(t)
+
 	organizationName := acctest.RandomWithPrefix("tf-acc-org")
 	ruleName := acctest.RandomWithPrefix("tf-acc-egress-rule")
 	resource.Test(t, resource.TestCase{
@@ -43,6 +57,8 @@ func TestAccAgynEgressRule_basic(t *testing.T) {
 }
 
 func TestAccAgynEgressRuleAttachment_basic(t *testing.T) {
+	skipUnlessTerraformEgressResourcesEnabled(t)
+
 	organizationName := acctest.RandomWithPrefix("tf-acc-org")
 	agentName := acctest.RandomWithPrefix("tf-acc-agent")
 	ruleName := acctest.RandomWithPrefix("tf-acc-egress-rule")


### PR DESCRIPTION
## Summary
- Gate only `TestAccAgynEgressRule_basic` and `TestAccAgynEgressRuleAttachment_basic` behind `AGYN_TF_EGRESS_RESOURCES=1`.
- Keep the Terraform egress tests compiled and visible with an explicit skip reason referencing `agynio/terraform-provider-agyn#82`.
- Added an inline removal note for when provider egress resources ship.
- No Playwright egress coverage was changed.

Fixes #209

## Tests
- `git diff --check` - passed
- `go test -count=1 -tags 'e2e svc_gateway tf_provider_agyn' -run 'TestAccAgynEgressRule' -v ./tests/...` - passed: 0 passed, 0 failed, 2 skipped
- `go test -count=1 -tags 'e2e svc_gateway tf_provider_agyn' -run '^$' ./tests/...` - passed: package compiled, no tests run

## Notes
- Full go-terraform acceptance execution requires AGYN_* environment variables and was not runnable locally in this workspace; baseline fails immediately on missing `AGYN_BASE_URL` / `AGYN_ORGANIZATION_ID`.