### PR TITLE
test(egress): expand e2e coverage

### DIFF
--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -409,7 +409,21 @@ EOF
       exec_env+=("LLM_PROXY_URL=https://llm.${e2e_domain}:${e2e_ingress_port}")
     fi
 
-    for env_name in AGYN_MODEL_ID AGYN_AGENT_IMAGE AGYN_AGENT_INIT_IMAGE AGYN_API_TOKEN AGYN_ORGANIZATION_ID EGRESS_DATAPLANE_BASE_URL EGRESS_DIRECT_BYPASS_URL EGRESS_DIRECT_BYPASS_HEADER EGRESS_DIRECT_BYPASS_HEADER_VALUE; do
+    forwarded_env_names=(
+      AGYN_MODEL_ID
+      AGYN_AGENT_IMAGE
+      AGYN_AGENT_INIT_IMAGE
+      AGYN_API_TOKEN
+      AGYN_ORGANIZATION_ID
+      EGRESS_DATAPLANE_BASE_URL
+      EGRESS_DIRECT_BYPASS_URL
+      EGRESS_DIRECT_BYPASS_HEADER
+      EGRESS_DIRECT_BYPASS_HEADER_VALUE
+      EGRESS_EXPECTED_CLUSTER_POD_CIDR
+      EGRESS_EXPECTED_CLUSTER_SERVICE_CIDR
+      EGRESS_EXPECTED_ADDITIONAL_INTERNAL_CIDRS
+    )
+    for env_name in "${forwarded_env_names[@]}"; do
       env_value=${!env_name:-}
       if [ -n "$env_value" ]; then
         exec_env+=("${env_name}=${env_value}")

--- a/suites/go-agn-cli/tests/egress_test.go
+++ b/suites/go-agn-cli/tests/egress_test.go
@@ -1,0 +1,201 @@
+//go:build e2e && svc_agn_cli
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	agynGatewayURLEnv     = "AGYN_BASE_URL"
+	agynAPITokenEnv       = "AGYN_API_TOKEN"
+	agynOrganizationIDEnv = "AGYN_ORGANIZATION_ID"
+)
+
+type agynEgressRuleOutput struct {
+	ID             string `json:"id"`
+	OrganizationID string `json:"organization_id"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	Matcher        struct {
+		DomainPattern string   `json:"domain_pattern"`
+		Ports         []int32  `json:"ports"`
+		Methods       []string `json:"methods"`
+		PathPattern   string   `json:"path_pattern"`
+	} `json:"matcher"`
+	Effect struct {
+		Action  string `json:"action"`
+		Headers []struct {
+			Name   string `json:"name"`
+			Scheme string `json:"scheme"`
+			Source string `json:"source"`
+		} `json:"headers"`
+	} `json:"effect"`
+}
+
+type agynEgressAttachmentOutput struct {
+	ID      string `json:"id"`
+	RuleID  string `json:"rule_id"`
+	AgentID string `json:"agent_id"`
+}
+
+func TestAgynEgressRuleLifecycle(t *testing.T) {
+	binary := agnBinaryPath(t)
+	env := newAgynCLIGatewayEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	organizationID := requireAgynCLIEnv(t, agynOrganizationIDEnv)
+	ruleName := "e2e-cli-egress-" + uniqueID()
+	updatedRuleName := ruleName + "-updated"
+	domainPattern := fmt.Sprintf("api-%s.example.com", uniqueID())
+	agentID := uniqueID()
+
+	createStdout, _ := runAgnWithContext(t, ctx, binary, env, "egress", "rule", "create",
+		"--organization-id", organizationID,
+		"--name", ruleName,
+		"--description", "E2E CLI egress rule",
+		"--domain", domainPattern,
+		"--port", "443",
+		"--method", "GET",
+		"--path", "/repos/**",
+		"--action", "allow",
+		"--header", "X-E2E-CLI=literal-token",
+		"--output", "json",
+	)
+	rule := decodeAgynEgressRule(t, createStdout)
+	require.NotEmpty(t, rule.ID)
+	require.Equal(t, organizationID, rule.OrganizationID)
+	require.Equal(t, ruleName, rule.Name)
+	require.Equal(t, domainPattern, rule.Matcher.DomainPattern)
+	require.Equal(t, []int32{443}, rule.Matcher.Ports)
+	require.Equal(t, []string{"GET"}, rule.Matcher.Methods)
+	require.Equal(t, "/repos/**", rule.Matcher.PathPattern)
+	require.Equal(t, "allow", rule.Effect.Action)
+	require.Len(t, rule.Effect.Headers, 1)
+	require.Equal(t, "X-E2E-CLI", rule.Effect.Headers[0].Name)
+	require.Equal(t, "value", rule.Effect.Headers[0].Source)
+
+	ruleID := rule.ID
+	deleted := false
+	defer func() {
+		if !deleted {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			_, _ = runAgnWithContextNoFail(cleanupCtx, binary, env, "egress", "rule", "delete", ruleID)
+		}
+	}()
+
+	listStdout, _ := runAgnWithContext(t, ctx, binary, env, "egress", "rule", "list", "--organization-id", organizationID, "--output", "json")
+	listedRules := decodeAgynEgressRuleList(t, listStdout)
+	requireAgynRuleID(t, listedRules, ruleID)
+
+	getStdout, _ := runAgnWithContext(t, ctx, binary, env, "egress", "rule", "get", ruleID, "--output", "json")
+	gotRule := decodeAgynEgressRule(t, getStdout)
+	require.Equal(t, ruleID, gotRule.ID)
+	require.Equal(t, ruleName, gotRule.Name)
+
+	updateStdout, _ := runAgnWithContext(t, ctx, binary, env, "egress", "rule", "update", ruleID,
+		"--name", updatedRuleName,
+		"--description", "E2E CLI egress rule updated",
+		"--domain", domainPattern,
+		"--port", "8443",
+		"--method", "POST",
+		"--path", "/repos/**/issues",
+		"--action", "deny",
+		"--header", "X-E2E-CLI=updated-literal-token",
+		"--output", "json",
+	)
+	updatedRule := decodeAgynEgressRule(t, updateStdout)
+	require.Equal(t, ruleID, updatedRule.ID)
+	require.Equal(t, updatedRuleName, updatedRule.Name)
+	require.Equal(t, []int32{8443}, updatedRule.Matcher.Ports)
+	require.Equal(t, []string{"POST"}, updatedRule.Matcher.Methods)
+	require.Equal(t, "/repos/**/issues", updatedRule.Matcher.PathPattern)
+	require.Equal(t, "deny", updatedRule.Effect.Action)
+
+	attachStdout, _ := runAgnWithContext(t, ctx, binary, env, "egress", "rule", "attach", ruleID, agentID, "--output", "json")
+	attachment := decodeAgynEgressAttachment(t, attachStdout)
+	require.NotEmpty(t, attachment.ID)
+	require.Equal(t, ruleID, attachment.RuleID)
+	require.Equal(t, agentID, attachment.AgentID)
+
+	_, _ = runAgnWithContext(t, ctx, binary, env, "egress", "rule", "detach", attachment.ID)
+	_, _ = runAgnWithContext(t, ctx, binary, env, "egress", "rule", "delete", ruleID)
+	deleted = true
+}
+
+func newAgynCLIGatewayEnv(t *testing.T) []string {
+	t.Helper()
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".agyn")
+	require.NoError(t, os.MkdirAll(configDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "credentials"), []byte(requireAgynCLIEnv(t, agynAPITokenEnv)+"\n"), 0o600))
+	return append(os.Environ(),
+		"HOME="+home,
+		"AGYN_GATEWAY_URL="+requireAgynCLIEnv(t, agynGatewayURLEnv),
+	)
+}
+
+func requireAgynCLIEnv(t *testing.T, key string) string {
+	t.Helper()
+	value := strings.TrimSpace(os.Getenv(key))
+	require.NotEmpty(t, value, "%s is required for agyn CLI live egress E2E", key)
+	return value
+}
+
+func decodeAgynEgressRule(t *testing.T, payload string) agynEgressRuleOutput {
+	t.Helper()
+	var rule agynEgressRuleOutput
+	require.NoError(t, json.Unmarshal([]byte(payload), &rule), "payload: %s", payload)
+	return rule
+}
+
+func decodeAgynEgressRuleList(t *testing.T, payload string) []agynEgressRuleOutput {
+	t.Helper()
+	var rules []agynEgressRuleOutput
+	require.NoError(t, json.Unmarshal([]byte(payload), &rules), "payload: %s", payload)
+	return rules
+}
+
+func decodeAgynEgressAttachment(t *testing.T, payload string) agynEgressAttachmentOutput {
+	t.Helper()
+	var attachment agynEgressAttachmentOutput
+	require.NoError(t, json.Unmarshal([]byte(payload), &attachment), "payload: %s", payload)
+	return attachment
+}
+
+func requireAgynRuleID(t *testing.T, rules []agynEgressRuleOutput, ruleID string) {
+	t.Helper()
+	for _, rule := range rules {
+		if rule.ID == ruleID {
+			return
+		}
+	}
+	t.Fatalf("egress rule %s not found in list response: %+v", ruleID, rules)
+}
+
+func runAgnWithContextNoFail(ctx context.Context, binary string, env []string, args ...string) (string, string) {
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Env = env
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	_ = cmd.Run()
+	return stdout.String(), stderr.String()
+}
+
+func uniqueID() string {
+	return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+}

--- a/suites/go-core/tests/egress_dataplane_test.go
+++ b/suites/go-core/tests/egress_dataplane_test.go
@@ -26,41 +26,56 @@ func TestEgressGatewayDataPlaneHTTPBehavior(t *testing.T) {
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	assertEgressHTTPStatus(t, ctx, client, baseURL+"/allowed", http.StatusOK)
-	assertEgressInjectedHeader(t, ctx, client, baseURL+"/allowed")
+	assertEgressInjectedHeader(t, ctx, client, baseURL+"/allowed", "X-E2E-Egress-Injected")
+	assertEgressInjectedHeader(t, ctx, client, baseURL+"/literal-header", "X-E2E-Egress-Literal")
+	assertEgressInjectedHeader(t, ctx, client, baseURL+"/secret-header", "X-E2E-Egress-Secret")
 	assertEgressHTTPStatus(t, ctx, client, baseURL+"/denied", http.StatusForbidden)
 	assertUnmatchedBypassesGateway(t, ctx, client, baseURL)
 	assertWebsocketUpgradeRequired(t, ctx, client, baseURL+"/ws")
 }
 
-func assertEgressHTTPStatus(t *testing.T, ctx context.Context, client *http.Client, url string, expected int) {
-	t.Helper()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		t.Fatalf("build request: %v", err)
+func TestEgressGatewayDataPlaneMatcherMatrix(t *testing.T) {
+	baseURL := strings.TrimRight(os.Getenv("EGRESS_DATAPLANE_BASE_URL"), "/")
+	if baseURL == "" {
+		t.Skip("EGRESS_DATAPLANE_BASE_URL is required for live egress data-plane checks")
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("perform egress request %s: %v", url, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != expected {
-		t.Fatalf("expected %s to return %d, got %d", url, expected, resp.StatusCode)
-	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), egressDataPlaneTimeout)
+	t.Cleanup(cancel)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	assertEgressRequest(t, ctx, client, http.MethodGet, baseURL+"/repos/agynio/e2e", http.StatusOK, "X-E2E-Egress-Path-Matched")
+	assertEgressRequest(t, ctx, client, http.MethodPost, baseURL+"/repos/agynio/e2e", http.StatusOK, "X-E2E-Egress-Method-Matched")
+	assertEgressRequest(t, ctx, client, http.MethodGet, baseURL+"/ports/8443", http.StatusOK, "X-E2E-Egress-Port-Matched")
+	assertEgressRequest(t, ctx, client, http.MethodGet, baseURL+"/repos", http.StatusNotFound, "")
 }
 
-func assertEgressInjectedHeader(t *testing.T, ctx context.Context, client *http.Client, url string) {
+func assertEgressHTTPStatus(t *testing.T, ctx context.Context, client *http.Client, url string, expected int) {
 	t.Helper()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	assertEgressRequest(t, ctx, client, http.MethodGet, url, expected, "")
+}
+
+func assertEgressInjectedHeader(t *testing.T, ctx context.Context, client *http.Client, url string, markerHeader string) {
+	t.Helper()
+	assertEgressRequest(t, ctx, client, http.MethodGet, url, http.StatusOK, markerHeader)
+}
+
+func assertEgressRequest(t *testing.T, ctx context.Context, client *http.Client, method string, url string, expectedStatus int, expectedHeader string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
-		t.Fatalf("build injected-header request: %v", err)
+		t.Fatalf("build egress request: %v", err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		t.Fatalf("perform injected-header request: %v", err)
+		t.Fatalf("perform egress request %s %s: %v", method, url, err)
 	}
 	defer resp.Body.Close()
-	if resp.Header.Get("X-E2E-Egress-Injected") == "" {
-		t.Fatalf("expected response to expose X-E2E-Egress-Injected marker")
+	if resp.StatusCode != expectedStatus {
+		t.Fatalf("expected %s %s to return %d, got %d", method, url, expectedStatus, resp.StatusCode)
+	}
+	if expectedHeader != "" && resp.Header.Get(expectedHeader) == "" {
+		t.Fatalf("expected %s %s response to expose %s marker", method, url, expectedHeader)
 	}
 }
 

--- a/suites/go-core/tests/egress_gateway_wiring_test.go
+++ b/suites/go-core/tests/egress_gateway_wiring_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,17 +21,20 @@ import (
 )
 
 const (
-	egressGatewayWiringTestTimeout = 3 * time.Minute
-	egressManagedByValue           = "agents-orchestrator"
-	egressGatewayHealthAddr        = "egress-gateway:50051"
-	egressGatewayHealthTimeout     = 30 * time.Second
-	egressNetworkPolicyName        = "agent-workload-egress"
-	egressCASecretName             = "egress-ca"
-	egressGatewayIdentitySecret    = "egress-gateway-ziti-identity"
-	egressZitiEnrollmentSecret     = "egress-gateway-enrollment"
-	egressCACertPath               = "/etc/agyn/egress-ca/ca.crt"
-	egressOpenZitiCIDR             = "100.64.0.0/10"
-	egressPublicInternetCIDR       = "0.0.0.0/0"
+	egressGatewayWiringTestTimeout   = 3 * time.Minute
+	egressManagedByValue             = "agents-orchestrator"
+	egressGatewayHealthAddr          = "egress-gateway:50051"
+	egressGatewayHealthTimeout       = 30 * time.Second
+	egressNetworkPolicyName          = "agent-workload-egress"
+	egressCASecretName               = "egress-ca"
+	egressGatewayIdentitySecret      = "egress-gateway-ziti-identity"
+	egressZitiEnrollmentSecret       = "egress-gateway-enrollment"
+	egressCACertPath                 = "/etc/agyn/egress-ca/ca.crt"
+	egressOpenZitiCIDR               = "100.64.0.0/10"
+	egressPublicInternetCIDR         = "0.0.0.0/0"
+	egressExpectedClusterPodCIDR     = "EGRESS_EXPECTED_CLUSTER_POD_CIDR"
+	egressExpectedClusterServiceCIDR = "EGRESS_EXPECTED_CLUSTER_SERVICE_CIDR"
+	egressExpectedAdditionalCIDRs    = "EGRESS_EXPECTED_ADDITIONAL_INTERNAL_CIDRS"
 )
 
 var egressDefaultBlockedCIDRs = []string{
@@ -120,9 +125,8 @@ func assertEgressWorkloadNetworkPolicy(t *testing.T, ctx context.Context) {
 	if !networkPolicyAllowsDNS(policy) {
 		t.Fatalf("network policy %s must allow DNS", egressNetworkPolicyName)
 	}
-	if !networkPolicyAllowsPublicInternetExceptBlockedCIDRs(policy, egressDefaultBlockedCIDRs) {
-		t.Fatalf("network policy %s must allow public internet %s with blocked CIDR exceptions %v", egressNetworkPolicyName, egressPublicInternetCIDR, egressDefaultBlockedCIDRs)
-	}
+	expectedCIDRs := expectedEgressNetworkPolicyExcludedCIDRs()
+	assertNetworkPolicyAllowsPublicInternetExceptCIDRs(t, policy, expectedCIDRs)
 }
 
 func assertEgressCAInlineWorkloadPath(t *testing.T, ctx context.Context) {
@@ -158,6 +162,19 @@ func assertEgressCAInlineWorkloadPath(t *testing.T, ctx context.Context) {
 	}
 }
 
+func expectedEgressNetworkPolicyExcludedCIDRs() []string {
+	cidrs := append([]string{}, egressDefaultBlockedCIDRs...)
+	for _, key := range []string{egressExpectedClusterPodCIDR, egressExpectedClusterServiceCIDR, egressExpectedAdditionalCIDRs} {
+		for _, cidr := range strings.Split(os.Getenv(key), ",") {
+			trimmed := strings.TrimSpace(cidr)
+			if trimmed != "" {
+				cidrs = append(cidrs, trimmed)
+			}
+		}
+	}
+	return cidrs
+}
+
 func networkPolicyHasType(types []networkingv1.PolicyType, expected networkingv1.PolicyType) bool {
 	for _, candidate := range types {
 		if candidate == expected {
@@ -178,31 +195,35 @@ func networkPolicyAllowsCIDR(policy *networkingv1.NetworkPolicy, cidr string) bo
 	return false
 }
 
-func networkPolicyAllowsPublicInternetExceptBlockedCIDRs(policy *networkingv1.NetworkPolicy, blockedCIDRs []string) bool {
+func assertNetworkPolicyAllowsPublicInternetExceptCIDRs(t *testing.T, policy *networkingv1.NetworkPolicy, blockedCIDRs []string) {
+	t.Helper()
 	for _, rule := range policy.Spec.Egress {
 		for _, peer := range rule.To {
 			if peer.IPBlock == nil || peer.IPBlock.CIDR != egressPublicInternetCIDR {
 				continue
 			}
-			if cidrSetContainsAll(peer.IPBlock.Except, blockedCIDRs) {
-				return true
+			missing := missingCIDRs(peer.IPBlock.Except, blockedCIDRs)
+			if len(missing) == 0 {
+				return
 			}
+			t.Fatalf("network policy %s public internet %s missing configured CIDR exceptions %v; actual exceptions %v", egressNetworkPolicyName, egressPublicInternetCIDR, missing, peer.IPBlock.Except)
 		}
 	}
-	return false
+	t.Fatalf("network policy %s must allow public internet %s with configured CIDR exceptions %v", egressNetworkPolicyName, egressPublicInternetCIDR, blockedCIDRs)
 }
 
-func cidrSetContainsAll(actual []string, expected []string) bool {
+func missingCIDRs(actual []string, expected []string) []string {
 	actualSet := make(map[string]struct{}, len(actual))
 	for _, cidr := range actual {
 		actualSet[cidr] = struct{}{}
 	}
+	missing := make([]string, 0)
 	for _, cidr := range expected {
 		if _, ok := actualSet[cidr]; !ok {
-			return false
+			missing = append(missing, cidr)
 		}
 	}
-	return true
+	return missing
 }
 
 func networkPolicyAllowsDNS(policy *networkingv1.NetworkPolicy) bool {

--- a/suites/go-core/tests/egress_k8s_runner_helpers_test.go
+++ b/suites/go-core/tests/egress_k8s_runner_helpers_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && svc_egress_gateway && !(svc_k8s_runner || smoke)
+//go:build e2e && svc_egress_gateway
 
 package tests
 

--- a/suites/playwright/test/e2e/organization-egress-rules.spec.ts
+++ b/suites/playwright/test/e2e/organization-egress-rules.spec.ts
@@ -24,9 +24,10 @@ test.describe('organization-egress-rules', { tag: ['@svc_console'] }, () => {
       name: `e2e-egress-provider-${now}`,
       url: 'https://vault.example.com',
     });
+    const secretName = `e2e-egress-secret-${now}`;
     const secretId = await createSecret(page, {
       providerId,
-      name: `e2e-egress-secret-${now}`,
+      name: secretName,
       value: `egress/token/${now}`,
       organizationId,
     });
@@ -50,6 +51,38 @@ test.describe('organization-egress-rules', { tag: ['@svc_console'] }, () => {
     await expect(page.getByTestId('egress-rules-heading')).toBeVisible({ timeout: 15000 });
     await expect(page.getByTestId('egress-rule-row').filter({ hasText: ruleName })).toBeVisible({ timeout: 15000 });
     await expect(page.getByTestId('nav-organization-egress-rules')).toBeVisible();
+
+    const uiRuleName = `e2e-egress-ui-rule-${now}`;
+    await page.getByTestId('egress-rules-create-button').click();
+    await expect(page.getByTestId('egress-rules-create-dialog')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('egress-rules-create-name').fill(uiRuleName);
+    await page.getByTestId('egress-rules-create-domain').fill(`ui-${now}.example.com`);
+    await page.getByTestId('egress-rules-create-ports').fill('443');
+    await page.getByTestId('egress-rules-create-methods').fill('GET');
+    await page.getByTestId('egress-rules-create-path').fill('/repos/**');
+    await page.getByTestId('egress-rules-create-add-header').click();
+    await page.getByTestId('egress-rules-create-header-name').fill('Authorization');
+    await page.getByTestId('egress-rules-create-header-scheme').click();
+    await page.getByRole('option', { name: 'Bearer' }).click();
+    await page.getByTestId('egress-rules-create-header-source').click();
+    await page.getByRole('option', { name: 'Secret' }).click();
+    await page.getByTestId('egress-rules-create-header-secret-search').fill(secretName);
+    await page.getByTestId('egress-rules-create-header-secret').click();
+    await page.getByRole('option', { name: secretName }).click();
+    await page.getByTestId('egress-rules-create-submit').click();
+    await expect(page.getByTestId('egress-rule-row').filter({ hasText: uiRuleName })).toBeVisible({ timeout: 15000 });
+
+    await page.getByTestId('egress-rules-create-button').click();
+    await expect(page.getByTestId('egress-rules-create-dialog')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('egress-rules-create-name').fill(`e2e-egress-invalid-${now}`);
+    await page.getByTestId('egress-rules-create-submit').click();
+    await expect(page.getByText('Domain pattern is required.')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('egress-rules-create-add-header').click();
+    await page.getByTestId('egress-rules-create-header-name').fill('Authorization');
+    await page.getByTestId('egress-rules-create-domain').fill(`invalid-${now}.example.com`);
+    await page.getByTestId('egress-rules-create-submit').click();
+    await expect(page.getByText('Each header requires a name and literal value or selected secret.')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('egress-rules-create-cancel').click();
 
     await page.goto(`/organizations/${organizationId}/agents/${agentId}`);
     await expect(page.getByTestId('agent-egress-rule-attachments-heading')).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
## Summary
- Add live `agyn` CLI egress rule lifecycle coverage for create/list/get/update/attach/detach/delete against Gateway.
- Extend Console Playwright org egress UI coverage for create navigation, Secret search/selection for injected headers, `/repos/**`, and validation errors.
- Expand egress data-plane assertions for allow, deny, unmatched bypass, literal header injection, Secret-backed header injection, and method/path/port matcher cases.
- Strengthen NetworkPolicy assertions for OpenZiti CIDR, DNS egress, default internal CIDR exclusions, and optional configured pod/service/additional internal CIDR exclusions via env vars.

Refs agynio/architecture#156

## Validation
- `CGO_ENABLED=0 go test -run '^$' -tags 'e2e svc_agn_cli' ./tests/...` from `suites/go-agn-cli`
- `CGO_ENABLED=0 go test -run '^$' -tags 'e2e svc_egress_gateway' ./tests/...` from `suites/go-core`
- `npm ci --no-fund --no-audit` from `suites/playwright`
- `PATH="$PWD/node_modules/.bin:$PATH" ./node_modules/.bin/buf generate && ./node_modules/.bin/tsc --noEmit` from `suites/playwright`
- `git diff --check`

## Notes
- Local Go package compile checks used `CGO_ENABLED=0` because this workspace does not have `gcc`; CI images provide the normal compiler toolchain.
- Runtime/data-plane checks rely on the existing suite-provided live fixture endpoints. New matrix paths/headers are explicit assertions; if a deployed fixture omits one, the test fails instead of silently skipping.